### PR TITLE
SD-941: Minor fixes (warnings, etc.)

### DIFF
--- a/docs/Echarts/AddData.md
+++ b/docs/Echarts/AddData.md
@@ -15,7 +15,7 @@ newtype AdditionalData
 
 ##### Instances
 ``` purescript
-instance additionalDataEncodeJson :: EncodeJson AdditionalData
+EncodeJson AdditionalData
 ```
 
 #### `addData`

--- a/docs/Echarts/Axis.md
+++ b/docs/Echarts/Axis.md
@@ -15,8 +15,8 @@ newtype AxisLineStyle
 
 ##### Instances
 ``` purescript
-instance axisLineStyleEncodeJson :: EncodeJson AxisLineStyle
-instance axisLineStyleDecodeJson :: DecodeJson AxisLineStyle
+EncodeJson AxisLineStyle
+DecodeJson AxisLineStyle
 ```
 
 #### `axisLineStyleDefault`
@@ -40,8 +40,8 @@ newtype AxisLine
 
 ##### Instances
 ``` purescript
-instance axisLineEncodeJson :: EncodeJson AxisLine
-instance axisLineDecodeJson :: DecodeJson AxisLine
+EncodeJson AxisLine
+DecodeJson AxisLine
 ```
 
 #### `axisLineDefault`
@@ -65,8 +65,8 @@ newtype AxisTick
 
 ##### Instances
 ``` purescript
-instance axisTickEncodeJson :: EncodeJson AxisTick
-instance axisTickDecodeJson :: DecodeJson AxisTick
+EncodeJson AxisTick
+DecodeJson AxisTick
 ```
 
 #### `axisTickDefault`
@@ -90,8 +90,8 @@ newtype AxisLabel
 
 ##### Instances
 ``` purescript
-instance axisLabelEncodeJson :: EncodeJson AxisLabel
-instance axisLabelDecodeJson :: DecodeJson AxisLabel
+EncodeJson AxisLabel
+DecodeJson AxisLabel
 ```
 
 #### `axisLabelDefault`
@@ -110,8 +110,8 @@ data Axises
 
 ##### Instances
 ``` purescript
-instance axisesEncodeJson :: EncodeJson Axises
-instance axisesDecodeJson :: DecodeJson Axises
+EncodeJson Axises
+DecodeJson Axises
 ```
 
 #### `AxisSplitLineRec`
@@ -129,8 +129,8 @@ newtype AxisSplitLine
 
 ##### Instances
 ``` purescript
-instance axisSplitLineEncodeJson :: EncodeJson AxisSplitLine
-instance axisSplitLineDecodeJson :: DecodeJson AxisSplitLine
+EncodeJson AxisSplitLine
+DecodeJson AxisSplitLine
 ```
 
 #### `axisSplitLineDefault`
@@ -154,8 +154,8 @@ newtype AxisSplitArea
 
 ##### Instances
 ``` purescript
-instance axisSplitAreaEncodeJson :: EncodeJson AxisSplitArea
-instance axisSplitAreaDecodeJson :: DecodeJson AxisSplitArea
+EncodeJson AxisSplitArea
+DecodeJson AxisSplitArea
 ```
 
 #### `axisSplitAreaDefault`
@@ -175,8 +175,8 @@ data AxisType
 
 ##### Instances
 ``` purescript
-instance axisTypeEncodeJson :: EncodeJson AxisType
-instance axisTypeDecodeJson :: DecodeJson AxisType
+EncodeJson AxisType
+DecodeJson AxisType
 ```
 
 #### `AxisPosition`
@@ -191,8 +191,8 @@ data AxisPosition
 
 ##### Instances
 ``` purescript
-instance axisPositionEncodeJson :: EncodeJson AxisPosition
-instance axisPositionDecodeJson :: DecodeJson AxisPosition
+EncodeJson AxisPosition
+DecodeJson AxisPosition
 ```
 
 #### `AxisNameLocation`
@@ -205,8 +205,8 @@ data AxisNameLocation
 
 ##### Instances
 ``` purescript
-instance axisNameLocationEncodeJson :: EncodeJson AxisNameLocation
-instance axisNameLocationDecodeJson :: DecodeJson AxisNameLocation
+EncodeJson AxisNameLocation
+DecodeJson AxisNameLocation
 ```
 
 #### `CustomAxisDataRec`
@@ -225,8 +225,8 @@ data AxisData
 
 ##### Instances
 ``` purescript
-instance axisDataEncodeJson :: EncodeJson AxisData
-instance axisDataDecodeJson :: DecodeJson AxisData
+EncodeJson AxisData
+DecodeJson AxisData
 ```
 
 #### `AxisBoundaryGap`
@@ -239,8 +239,8 @@ data AxisBoundaryGap
 
 ##### Instances
 ``` purescript
-instance axisBoundaryGapEncodeJson :: EncodeJson AxisBoundaryGap
-instance axisBoundaryGapDecodeJson :: DecodeJson AxisBoundaryGap
+EncodeJson AxisBoundaryGap
+DecodeJson AxisBoundaryGap
 ```
 
 #### `AxisRec`
@@ -258,8 +258,8 @@ newtype Axis
 
 ##### Instances
 ``` purescript
-instance axisEncJson :: EncodeJson Axis
-instance axisDecJson :: DecodeJson Axis
+EncodeJson Axis
+DecodeJson Axis
 ```
 
 #### `axisDefault`
@@ -283,8 +283,8 @@ newtype PolarName
 
 ##### Instances
 ``` purescript
-instance polarNameEncode :: EncodeJson PolarName
-instance polarNameDecodeJson :: DecodeJson PolarName
+EncodeJson PolarName
+DecodeJson PolarName
 ```
 
 #### `polarNameDefault`
@@ -303,8 +303,8 @@ data PolarType
 
 ##### Instances
 ``` purescript
-instance polarTypeEncode :: EncodeJson PolarType
-instance polarTypeDecodeJson :: DecodeJson PolarType
+EncodeJson PolarType
+DecodeJson PolarType
 ```
 
 #### `IndicatorRec`
@@ -322,8 +322,8 @@ newtype Indicator
 
 ##### Instances
 ``` purescript
-instance indicatorEncodeJson :: EncodeJson Indicator
-instance indicatorDecodeJson :: DecodeJson Indicator
+EncodeJson Indicator
+DecodeJson Indicator
 ```
 
 #### `indicatorDefault`
@@ -347,8 +347,8 @@ newtype Polar
 
 ##### Instances
 ``` purescript
-instance polarEncodeJson :: EncodeJson Polar
-instance polarDecodeJson :: DecodeJson Polar
+EncodeJson Polar
+DecodeJson Polar
 ```
 
 #### `polarDefault`

--- a/docs/Echarts/Chart.md
+++ b/docs/Echarts/Chart.md
@@ -22,7 +22,7 @@ data Theme
 
 ##### Instances
 ``` purescript
-instance themeEncodeJson :: EncodeJson Theme
+EncodeJson Theme
 ```
 
 #### `init`

--- a/docs/Echarts/Color.md
+++ b/docs/Echarts/Color.md
@@ -29,8 +29,8 @@ data CalculableColor
 
 ##### Instances
 ``` purescript
-instance calculableColorEncodeJson :: EncodeJson CalculableColor
-instance calculableColorDecodeJson :: DecodeJson CalculableColor
+EncodeJson CalculableColor
+DecodeJson CalculableColor
 ```
 
 

--- a/docs/Echarts/Common.md
+++ b/docs/Echarts/Common.md
@@ -16,8 +16,8 @@ data Corner a
 
 ##### Instances
 ``` purescript
-instance cornerJsonEncode :: (EncodeJson a) => EncodeJson (Corner a)
-instance cornerJsonDecode :: (DecodeJson a) => DecodeJson (Corner a)
+(EncodeJson a) => EncodeJson (Corner a)
+(DecodeJson a) => DecodeJson (Corner a)
 ```
 
 #### `PercentOrPixel`
@@ -30,8 +30,8 @@ data PercentOrPixel
 
 ##### Instances
 ``` purescript
-instance percentOrPixelEncodeJson :: EncodeJson PercentOrPixel
-instance percentOrPixelDecodeJson :: DecodeJson PercentOrPixel
+EncodeJson PercentOrPixel
+DecodeJson PercentOrPixel
 ```
 
 #### `RoseType`
@@ -44,8 +44,8 @@ data RoseType
 
 ##### Instances
 ``` purescript
-instance roseTypeEncodeJson :: EncodeJson RoseType
-instance roseTypeDecodeJson :: DecodeJson RoseType
+EncodeJson RoseType
+DecodeJson RoseType
 ```
 
 #### `SelectedMode`
@@ -59,8 +59,8 @@ data SelectedMode
 
 ##### Instances
 ``` purescript
-instance selModeEncodeJson :: EncodeJson SelectedMode
-instance selModeDecodeJson :: DecodeJson SelectedMode
+EncodeJson SelectedMode
+DecodeJson SelectedMode
 ```
 
 #### `MapValueCalculation`
@@ -73,8 +73,8 @@ data MapValueCalculation
 
 ##### Instances
 ``` purescript
-instance mapValueCalculationEncodeJson :: EncodeJson MapValueCalculation
-instance mapValueCalculationDecodeJson :: DecodeJson MapValueCalculation
+EncodeJson MapValueCalculation
+DecodeJson MapValueCalculation
 ```
 
 #### `Roam`
@@ -89,8 +89,8 @@ data Roam
 
 ##### Instances
 ``` purescript
-instance roamEncodeJson :: EncodeJson Roam
-instance roamDecodeJson :: DecodeJson Roam
+EncodeJson Roam
+DecodeJson Roam
 ```
 
 #### `MinMaxRec`
@@ -108,8 +108,8 @@ newtype MinMax
 
 ##### Instances
 ``` purescript
-instance minMaxEncodeJson :: EncodeJson MinMax
-instance minMaxDecodeJson :: DecodeJson MinMax
+EncodeJson MinMax
+DecodeJson MinMax
 ```
 
 #### `Center`
@@ -134,8 +134,8 @@ data Radius
 
 ##### Instances
 ``` purescript
-instance radiusEncodeJson :: EncodeJson Radius
-instance radiusDecodeJson :: DecodeJson Radius
+EncodeJson Radius
+DecodeJson Radius
 ```
 
 #### `Sort`
@@ -149,8 +149,8 @@ data Sort
 
 ##### Instances
 ``` purescript
-instance sortEncodeJson :: EncodeJson Sort
-instance sortDecodeJson :: DecodeJson Sort
+EncodeJson Sort
+DecodeJson Sort
 ```
 
 #### `Interval`
@@ -163,8 +163,8 @@ data Interval
 
 ##### Instances
 ``` purescript
-instance intervalEncodeJson :: EncodeJson Interval
-instance intervalDecodeJson :: DecodeJson Interval
+EncodeJson Interval
+DecodeJson Interval
 ```
 
 

--- a/docs/Echarts/Coords.md
+++ b/docs/Echarts/Coords.md
@@ -12,8 +12,8 @@ data XPos
 
 ##### Instances
 ``` purescript
-instance xPosEncodeJson :: EncodeJson XPos
-instance xPosDecodeJson :: DecodeJson XPos
+EncodeJson XPos
+DecodeJson XPos
 ```
 
 #### `YPos`
@@ -28,8 +28,8 @@ data YPos
 
 ##### Instances
 ``` purescript
-instance yPosEncodeJson :: EncodeJson YPos
-instance yPosDecodeJson :: DecodeJson YPos
+EncodeJson YPos
+DecodeJson YPos
 ```
 
 #### `LabelPosition`
@@ -51,8 +51,8 @@ data LabelPosition
 
 ##### Instances
 ``` purescript
-instance labelPositionEncodeJson :: EncodeJson LabelPosition
-instance labelPositionDecodeJson :: DecodeJson LabelPosition
+EncodeJson LabelPosition
+DecodeJson LabelPosition
 ```
 
 #### `HorizontalAlign`
@@ -66,8 +66,8 @@ data HorizontalAlign
 
 ##### Instances
 ``` purescript
-instance textAlignEncodeJson :: EncodeJson HorizontalAlign
-instance textAlignDecodeJson :: DecodeJson HorizontalAlign
+EncodeJson HorizontalAlign
+DecodeJson HorizontalAlign
 ```
 
 #### `LocationRec`
@@ -85,8 +85,8 @@ newtype Location
 
 ##### Instances
 ``` purescript
-instance locationEncodeJson :: EncodeJson Location
-instance locationDecodeJson :: DecodeJson Location
+EncodeJson Location
+DecodeJson Location
 ```
 
 #### `Orient`
@@ -99,8 +99,8 @@ data Orient
 
 ##### Instances
 ``` purescript
-instance orientEncodeJson :: EncodeJson Orient
-instance orientDecodeJson :: DecodeJson Orient
+EncodeJson Orient
+DecodeJson Orient
 ```
 
 

--- a/docs/Echarts/DataRange.md
+++ b/docs/Echarts/DataRange.md
@@ -15,8 +15,8 @@ newtype DataRange
 
 ##### Instances
 ``` purescript
-instance dataRangeEncodeJson :: EncodeJson DataRange
-instance dataRangeDecodeJson :: DecodeJson DataRange
+EncodeJson DataRange
+DecodeJson DataRange
 ```
 
 #### `dataRangeDefault`

--- a/docs/Echarts/DataZoom.md
+++ b/docs/Echarts/DataZoom.md
@@ -15,8 +15,8 @@ newtype DataZoom
 
 ##### Instances
 ``` purescript
-instance dataZoomEncodeJson :: EncodeJson DataZoom
-instance dataZoomDecodeJson :: DecodeJson DataZoom
+EncodeJson DataZoom
+DecodeJson DataZoom
 ```
 
 #### `dataZoomDefault`

--- a/docs/Echarts/Formatter.md
+++ b/docs/Echarts/Formatter.md
@@ -16,8 +16,8 @@ data Formatter
 
 ##### Instances
 ``` purescript
-instance formatterEncodeJson :: EncodeJson Formatter
-instance formatterDecodeJson :: DecodeJson Formatter
+EncodeJson Formatter
+DecodeJson Formatter
 ```
 
 

--- a/docs/Echarts/Grid.md
+++ b/docs/Echarts/Grid.md
@@ -15,8 +15,8 @@ newtype Grid
 
 ##### Instances
 ``` purescript
-instance gridEncodeJson :: EncodeJson Grid
-instance gridDecodeJson :: DecodeJson Grid
+EncodeJson Grid
+DecodeJson Grid
 ```
 
 #### `gridDefault`

--- a/docs/Echarts/Image.md
+++ b/docs/Echarts/Image.md
@@ -10,8 +10,8 @@ data ImgType
 
 ##### Instances
 ``` purescript
-instance encodeImg :: EncodeJson ImgType
-instance decodeImg :: DecodeJson ImgType
+EncodeJson ImgType
+DecodeJson ImgType
 ```
 
 #### `getDataURL`

--- a/docs/Echarts/Item.Data.md
+++ b/docs/Echarts/Item.Data.md
@@ -17,8 +17,8 @@ data ItemData
 
 ##### Instances
 ``` purescript
-instance itemDataEncodeJson :: EncodeJson ItemData
-instance itemDataDecodeJson :: DecodeJson ItemData
+EncodeJson ItemData
+DecodeJson ItemData
 ```
 
 #### `dataDefault`

--- a/docs/Echarts/Item.Value.md
+++ b/docs/Echarts/Item.Value.md
@@ -25,8 +25,8 @@ data ItemValue
 
 ##### Instances
 ``` purescript
-instance itemValueEncodeJson :: EncodeJson ItemValue
-instance itemValueDecodeJson :: DecodeJson ItemValue
+EncodeJson ItemValue
+DecodeJson ItemValue
 ```
 
 

--- a/docs/Echarts/Legend.md
+++ b/docs/Echarts/Legend.md
@@ -15,8 +15,8 @@ data LegendItem
 
 ##### Instances
 ``` purescript
-instance legendItemEncodeJson :: EncodeJson LegendItem
-instance legendItemDecodeJson :: DecodeJson LegendItem
+EncodeJson LegendItem
+DecodeJson LegendItem
 ```
 
 #### `legendItemDefault`
@@ -40,8 +40,8 @@ newtype Legend
 
 ##### Instances
 ``` purescript
-instance legendEncodeJson :: EncodeJson Legend
-instance legendDecodeJson :: DecodeJson Legend
+EncodeJson Legend
+DecodeJson Legend
 ```
 
 #### `legendDefault`

--- a/docs/Echarts/Loading.md
+++ b/docs/Echarts/Loading.md
@@ -14,7 +14,7 @@ data LoadingEffect
 
 ##### Instances
 ``` purescript
-instance loadingEffectEncodeJson :: EncodeJson LoadingEffect
+EncodeJson LoadingEffect
 ```
 
 #### `LoadingOptionRec`
@@ -32,7 +32,7 @@ newtype LoadingOption
 
 ##### Instances
 ``` purescript
-instance showLoadingOptions :: EncodeJson LoadingOption
+EncodeJson LoadingOption
 ```
 
 #### `showLoading`

--- a/docs/Echarts/Mark.Data.md
+++ b/docs/Echarts/Mark.Data.md
@@ -15,8 +15,8 @@ newtype MarkPointData
 
 ##### Instances
 ``` purescript
-instance mpDataEncodeJson :: EncodeJson MarkPointData
-instance mpDataDecodeJson :: DecodeJson MarkPointData
+EncodeJson MarkPointData
+DecodeJson MarkPointData
 ```
 
 #### `markPointDataDefault`

--- a/docs/Echarts/Mark.Effect.md
+++ b/docs/Echarts/Mark.Effect.md
@@ -15,8 +15,8 @@ newtype MarkPointEffect
 
 ##### Instances
 ``` purescript
-instance mpEffectEncodeJson :: EncodeJson MarkPointEffect
-instance mpEffectDecodeJson :: DecodeJson MarkPointEffect
+EncodeJson MarkPointEffect
+DecodeJson MarkPointEffect
 ```
 
 #### `markPointEffectDefault`

--- a/docs/Echarts/Mark.Line.md
+++ b/docs/Echarts/Mark.Line.md
@@ -15,8 +15,8 @@ newtype MarkLine
 
 ##### Instances
 ``` purescript
-instance mlEncodeJson :: EncodeJson MarkLine
-instance mlDecodeJson :: DecodeJson MarkLine
+EncodeJson MarkLine
+DecodeJson MarkLine
 ```
 
 #### `markLineDefault`

--- a/docs/Echarts/Mark.Point.md
+++ b/docs/Echarts/Mark.Point.md
@@ -15,8 +15,8 @@ newtype MarkPoint
 
 ##### Instances
 ``` purescript
-instance markPointEncodeJson :: EncodeJson MarkPoint
-instance markPointDecodeJson :: DecodeJson MarkPoint
+EncodeJson MarkPoint
+DecodeJson MarkPoint
 ```
 
 #### `markPointDefault`

--- a/docs/Echarts/Options.md
+++ b/docs/Echarts/Options.md
@@ -15,8 +15,8 @@ newtype Option
 
 ##### Instances
 ``` purescript
-instance optionsEncodeJson :: EncodeJson Option
-instance optionsDecodeJson :: DecodeJson Option
+EncodeJson Option
+DecodeJson Option
 ```
 
 #### `optionDefault`

--- a/docs/Echarts/RoamController.md
+++ b/docs/Echarts/RoamController.md
@@ -15,8 +15,8 @@ newtype RoamController
 
 ##### Instances
 ``` purescript
-instance roamControllerEncodeJson :: EncodeJson RoamController
-instance roamControllerDecodeJson :: DecodeJson RoamController
+EncodeJson RoamController
+DecodeJson RoamController
 ```
 
 #### `roamControllerDefault`

--- a/docs/Echarts/Series.EventRiver.md
+++ b/docs/Echarts/Series.EventRiver.md
@@ -15,8 +15,8 @@ newtype EvolutionDetail
 
 ##### Instances
 ``` purescript
-instance evoDetailEncodeJson :: EncodeJson EvolutionDetail
-instance evoDetailDecodeJson :: DecodeJson EvolutionDetail
+EncodeJson EvolutionDetail
+DecodeJson EvolutionDetail
 ```
 
 #### `evolutionDetailDefault`
@@ -40,8 +40,8 @@ newtype Evolution
 
 ##### Instances
 ``` purescript
-instance evoEncodeJson :: EncodeJson Evolution
-instance evoDecodeJson :: DecodeJson Evolution
+EncodeJson Evolution
+DecodeJson Evolution
 ```
 
 #### `OneEventRec`
@@ -59,8 +59,8 @@ newtype OneEvent
 
 ##### Instances
 ``` purescript
-instance oneEventEncodeJson :: EncodeJson OneEvent
-instance oneEventDecodeJson :: DecodeJson OneEvent
+EncodeJson OneEvent
+DecodeJson OneEvent
 ```
 
 #### `oneEventDefault`

--- a/docs/Echarts/Series.Force.md
+++ b/docs/Echarts/Series.Force.md
@@ -15,8 +15,8 @@ newtype ForceCategory
 
 ##### Instances
 ``` purescript
-instance forceCategoryEncodeJson :: EncodeJson ForceCategory
-instance forceCategoryDecodeJson :: DecodeJson ForceCategory
+EncodeJson ForceCategory
+DecodeJson ForceCategory
 ```
 
 #### `forceCategoryDefault`
@@ -40,8 +40,8 @@ newtype Node
 
 ##### Instances
 ``` purescript
-instance nodeEncodeJson :: EncodeJson Node
-instance nodeDecodeJson :: DecodeJson Node
+EncodeJson Node
+DecodeJson Node
 ```
 
 #### `nodeDefault`
@@ -60,8 +60,8 @@ data LinkEnd
 
 ##### Instances
 ``` purescript
-instance linkEndEncodeJson :: EncodeJson LinkEnd
-instance linkEndDecodeJson :: DecodeJson LinkEnd
+EncodeJson LinkEnd
+DecodeJson LinkEnd
 ```
 
 #### `LinkRec`
@@ -79,8 +79,8 @@ newtype Link
 
 ##### Instances
 ``` purescript
-instance linkEncodeJson :: EncodeJson Link
-instance linkDecodeJson :: DecodeJson Link
+EncodeJson Link
+DecodeJson Link
 ```
 
 #### `Matrix`

--- a/docs/Echarts/Series.Gauge.md
+++ b/docs/Echarts/Series.Gauge.md
@@ -15,8 +15,8 @@ newtype Pointer
 
 ##### Instances
 ``` purescript
-instance pointerEncodeJson :: EncodeJson Pointer
-instance pointerDecodeJson :: DecodeJson Pointer
+EncodeJson Pointer
+DecodeJson Pointer
 ```
 
 #### `pointerDefault`
@@ -40,8 +40,8 @@ newtype SplitLine
 
 ##### Instances
 ``` purescript
-instance splitLineEncodeJson :: EncodeJson SplitLine
-instance splitLineDecodeJson :: DecodeJson SplitLine
+EncodeJson SplitLine
+DecodeJson SplitLine
 ```
 
 #### `splitLineDefault`
@@ -65,8 +65,8 @@ newtype GaugeDetail
 
 ##### Instances
 ``` purescript
-instance gaugeDetailEncodeJson :: EncodeJson GaugeDetail
-instance gaugeDetailDecodeJson :: DecodeJson GaugeDetail
+EncodeJson GaugeDetail
+DecodeJson GaugeDetail
 ```
 
 #### `gaugeDetailDefault`

--- a/docs/Echarts/Series.md
+++ b/docs/Echarts/Series.md
@@ -20,8 +20,8 @@ data Series
 
 ##### Instances
 ``` purescript
-instance encodeSeries :: EncodeJson Series
-instance decodeSeries :: DecodeJson Series
+EncodeJson Series
+DecodeJson Series
 ```
 
 #### `UniversalSeriesRec`

--- a/docs/Echarts/Style.Area.md
+++ b/docs/Echarts/Style.Area.md
@@ -9,8 +9,8 @@ newtype AreaStyle
 
 ##### Instances
 ``` purescript
-instance areaStyleEncodeJson :: EncodeJson AreaStyle
-instance areaStyleDecodeJson :: DecodeJson AreaStyle
+EncodeJson AreaStyle
+DecodeJson AreaStyle
 ```
 
 

--- a/docs/Echarts/Style.Checkpoint.md
+++ b/docs/Echarts/Style.Checkpoint.md
@@ -15,8 +15,8 @@ newtype CheckpointStyle
 
 ##### Instances
 ``` purescript
-instance checkpointStyleEncodeJson :: EncodeJson CheckpointStyle
-instance checkpointStyleDecodeJson :: DecodeJson CheckpointStyle
+EncodeJson CheckpointStyle
+DecodeJson CheckpointStyle
 ```
 
 #### `checkpointStyleDefault`

--- a/docs/Echarts/Style.Chord.md
+++ b/docs/Echarts/Style.Chord.md
@@ -15,8 +15,8 @@ newtype ChordStyle
 
 ##### Instances
 ``` purescript
-instance chordStyleJson :: EncodeJson ChordStyle
-instance chordStyleDecodeJson :: DecodeJson ChordStyle
+EncodeJson ChordStyle
+DecodeJson ChordStyle
 ```
 
 #### `chordStyleDefault`

--- a/docs/Echarts/Style.Item.md
+++ b/docs/Echarts/Style.Item.md
@@ -15,8 +15,8 @@ newtype ItemLabel
 
 ##### Instances
 ``` purescript
-instance itemLabelEncodeJson :: EncodeJson ItemLabel
-instance itemLabelDecodeJson :: DecodeJson ItemLabel
+EncodeJson ItemLabel
+DecodeJson ItemLabel
 ```
 
 #### `itemLabelDefault`
@@ -40,8 +40,8 @@ newtype ItemLabelLine
 
 ##### Instances
 ``` purescript
-instance itemLabelLineEncodeJson :: EncodeJson ItemLabelLine
-instance itemLabelLineDecodeJson :: DecodeJson ItemLabelLine
+EncodeJson ItemLabelLine
+DecodeJson ItemLabelLine
 ```
 
 #### `itemLabelLineDefault`
@@ -65,8 +65,8 @@ newtype IStyle
 
 ##### Instances
 ``` purescript
-instance istyleEncodeJson :: EncodeJson IStyle
-instance istyleDecodeJson :: DecodeJson IStyle
+EncodeJson IStyle
+DecodeJson IStyle
 ```
 
 #### `istyleDefault`
@@ -90,8 +90,8 @@ newtype ItemStyle
 
 ##### Instances
 ``` purescript
-instance itemStyleEncodeJson :: EncodeJson ItemStyle
-instance itemStyleDecodeJson :: DecodeJson ItemStyle
+EncodeJson ItemStyle
+DecodeJson ItemStyle
 ```
 
 #### `itemStyleDefault`

--- a/docs/Echarts/Style.Line.md
+++ b/docs/Echarts/Style.Line.md
@@ -11,8 +11,8 @@ data LineType
 
 ##### Instances
 ``` purescript
-instance linetypeEncodeJson :: EncodeJson LineType
-instance linetypeDecodeJson :: DecodeJson LineType
+EncodeJson LineType
+DecodeJson LineType
 ```
 
 #### `LineStyleRec`
@@ -30,8 +30,8 @@ newtype LineStyle
 
 ##### Instances
 ``` purescript
-instance lineStyleEncodeJson :: EncodeJson LineStyle
-instance lineStyleDecodeJson :: DecodeJson LineStyle
+EncodeJson LineStyle
+DecodeJson LineStyle
 ```
 
 #### `lineStyleDefault`

--- a/docs/Echarts/Style.Link.md
+++ b/docs/Echarts/Style.Link.md
@@ -10,8 +10,8 @@ data LinkType
 
 ##### Instances
 ``` purescript
-instance linkTypeEncodeJson :: EncodeJson LinkType
-instance linkTypeDecodeJson :: DecodeJson LinkType
+EncodeJson LinkType
+DecodeJson LinkType
 ```
 
 #### `LinkStyleRec`
@@ -29,8 +29,8 @@ newtype LinkStyle
 
 ##### Instances
 ``` purescript
-instance linkStyleEncodeJson :: EncodeJson LinkStyle
-instance linkStyleDecodeJson :: DecodeJson LinkStyle
+EncodeJson LinkStyle
+DecodeJson LinkStyle
 ```
 
 #### `linkStyleDefault`

--- a/docs/Echarts/Style.Node.md
+++ b/docs/Echarts/Style.Node.md
@@ -15,8 +15,8 @@ newtype NodeStyle
 
 ##### Instances
 ``` purescript
-instance nodeStyleEncodeJson :: EncodeJson NodeStyle
-instance nodeStyleDecodeJson :: DecodeJson NodeStyle
+EncodeJson NodeStyle
+DecodeJson NodeStyle
 ```
 
 #### `nodeStyleDefault`

--- a/docs/Echarts/Style.Text.md
+++ b/docs/Echarts/Style.Text.md
@@ -23,8 +23,8 @@ data TextBaseline
 
 ##### Instances
 ``` purescript
-instance textBaselineEncodeJson :: EncodeJson TextBaseline
-instance textBaselineDecodeJson :: DecodeJson TextBaseline
+EncodeJson TextBaseline
+DecodeJson TextBaseline
 ```
 
 #### `FontStyle`
@@ -38,8 +38,8 @@ data FontStyle
 
 ##### Instances
 ``` purescript
-instance fontStyleEncodeJson :: EncodeJson FontStyle
-instance fontStyleDecodeJson :: DecodeJson FontStyle
+EncodeJson FontStyle
+DecodeJson FontStyle
 ```
 
 #### `FontWeight`
@@ -63,8 +63,8 @@ data FontWeight
 
 ##### Instances
 ``` purescript
-instance fontWeightEncodeJson :: EncodeJson FontWeight
-instance fontWeightDecodeJson :: DecodeJson FontWeight
+EncodeJson FontWeight
+DecodeJson FontWeight
 ```
 
 #### `TextStyleRec`
@@ -82,8 +82,8 @@ newtype TextStyle
 
 ##### Instances
 ``` purescript
-instance textStyleEncodeJson :: EncodeJson TextStyle
-instance textStyleDecodeJson :: DecodeJson TextStyle
+EncodeJson TextStyle
+DecodeJson TextStyle
 ```
 
 #### `textStyleDefault`

--- a/docs/Echarts/Symbol.md
+++ b/docs/Echarts/Symbol.md
@@ -16,8 +16,8 @@ data Symbol
 
 ##### Instances
 ``` purescript
-instance encodeJsonSymbol :: EncodeJson Symbol
-instance symbolDecodeJson :: DecodeJson Symbol
+EncodeJson Symbol
+DecodeJson Symbol
 ```
 
 #### `SymbolSize`
@@ -30,8 +30,8 @@ data SymbolSize
 
 ##### Instances
 ``` purescript
-instance symbolSizeEncodeJson :: EncodeJson SymbolSize
-instance symbolSizeDecodeJson :: DecodeJson SymbolSize
+EncodeJson SymbolSize
+DecodeJson SymbolSize
 ```
 
 #### `DoubleSymbolSize`
@@ -44,8 +44,8 @@ data DoubleSymbolSize
 
 ##### Instances
 ``` purescript
-instance dblSymbolSizeEncodeJson :: EncodeJson DoubleSymbolSize
-instance dblSymbolSizeDecodeJson :: DecodeJson DoubleSymbolSize
+EncodeJson DoubleSymbolSize
+DecodeJson DoubleSymbolSize
 ```
 
 

--- a/docs/Echarts/Timeline.md
+++ b/docs/Echarts/Timeline.md
@@ -10,8 +10,8 @@ data TimelineType
 
 ##### Instances
 ``` purescript
-instance timelineTypeEncodeJson :: EncodeJson TimelineType
-instance timelineTypeDecodeJson :: DecodeJson TimelineType
+EncodeJson TimelineType
+DecodeJson TimelineType
 ```
 
 #### `TimelineControlPosition`
@@ -25,8 +25,8 @@ data TimelineControlPosition
 
 ##### Instances
 ``` purescript
-instance timelineControlPositionEncodeJson :: EncodeJson TimelineControlPosition
-instance timelineControlPositionDecodeJson :: DecodeJson TimelineControlPosition
+EncodeJson TimelineControlPosition
+DecodeJson TimelineControlPosition
 ```
 
 #### `TimelineRec`
@@ -44,8 +44,8 @@ newtype Timeline
 
 ##### Instances
 ``` purescript
-instance timelineEncodeJson :: EncodeJson Timeline
-instance timelineDecodeJson :: DecodeJson Timeline
+EncodeJson Timeline
+DecodeJson Timeline
 ```
 
 #### `timelineDefault`

--- a/docs/Echarts/Title.md
+++ b/docs/Echarts/Title.md
@@ -10,8 +10,8 @@ data LinkTarget
 
 ##### Instances
 ``` purescript
-instance linkTargetEncodeJson :: EncodeJson LinkTarget
-instance linkTargetDecodeJson :: DecodeJson LinkTarget
+EncodeJson LinkTarget
+DecodeJson LinkTarget
 ```
 
 #### `TitleRec`
@@ -29,8 +29,8 @@ newtype Title
 
 ##### Instances
 ``` purescript
-instance titleEncodeJson :: EncodeJson Title
-instance titleDecodeJson :: DecodeJson Title
+EncodeJson Title
+DecodeJson Title
 ```
 
 #### `titleDefault`

--- a/docs/Echarts/Toolbox.md
+++ b/docs/Echarts/Toolbox.md
@@ -15,8 +15,8 @@ newtype Toolbox
 
 ##### Instances
 ``` purescript
-instance toolboxEncodeJson :: EncodeJson Toolbox
-instance toolboxDecodeJson :: DecodeJson Toolbox
+EncodeJson Toolbox
+DecodeJson Toolbox
 ```
 
 #### `toolboxDefault`
@@ -40,8 +40,8 @@ newtype Feature
 
 ##### Instances
 ``` purescript
-instance featureEncodeJson :: EncodeJson Feature
-instance featureDecodeJson :: DecodeJson Feature
+EncodeJson Feature
+DecodeJson Feature
 ```
 
 #### `featureDefault`
@@ -65,8 +65,8 @@ newtype SaveAsImageFeature
 
 ##### Instances
 ``` purescript
-instance saveAsImageEncodeJson :: EncodeJson SaveAsImageFeature
-instance saveAsImageDecodeJson :: DecodeJson SaveAsImageFeature
+EncodeJson SaveAsImageFeature
+DecodeJson SaveAsImageFeature
 ```
 
 #### `saveAsImageFeatureDefault`
@@ -90,8 +90,8 @@ newtype RestoreFeature
 
 ##### Instances
 ``` purescript
-instance restoreFeatureEncodeJson :: EncodeJson RestoreFeature
-instance restoreFeatureDecodeJson :: DecodeJson RestoreFeature
+EncodeJson RestoreFeature
+DecodeJson RestoreFeature
 ```
 
 #### `restoreFeatureDefault`
@@ -115,8 +115,8 @@ newtype DataZoomFeatureTitle
 
 ##### Instances
 ``` purescript
-instance datazoomTitleEncodeJson :: EncodeJson DataZoomFeatureTitle
-instance datazoomTitleDecodeJson :: DecodeJson DataZoomFeatureTitle
+EncodeJson DataZoomFeatureTitle
+DecodeJson DataZoomFeatureTitle
 ```
 
 #### `DataZoomFeatureRec`
@@ -134,8 +134,8 @@ newtype DataZoomFeature
 
 ##### Instances
 ``` purescript
-instance dataZoomFeatureEncodeJson :: EncodeJson DataZoomFeature
-instance dataZoomFeatureDecodeJson :: DecodeJson DataZoomFeature
+EncodeJson DataZoomFeature
+DecodeJson DataZoomFeature
 ```
 
 #### `dataZoomFeatureDefault`
@@ -159,8 +159,8 @@ newtype DataViewFeature
 
 ##### Instances
 ``` purescript
-instance dataViewFeatureEncodeJson :: EncodeJson DataViewFeature
-instance dataViewFeatureDecodeJson :: DecodeJson DataViewFeature
+EncodeJson DataViewFeature
+DecodeJson DataViewFeature
 ```
 
 #### `dataViewFeatureDefault`
@@ -184,8 +184,8 @@ newtype MarkFeatureTitle
 
 ##### Instances
 ``` purescript
-instance mftitleEncodeJson :: EncodeJson MarkFeatureTitle
-instance mftitleDecodeJson :: DecodeJson MarkFeatureTitle
+EncodeJson MarkFeatureTitle
+DecodeJson MarkFeatureTitle
 ```
 
 #### `MarkFeatureRec`
@@ -203,8 +203,8 @@ newtype MarkFeature
 
 ##### Instances
 ``` purescript
-instance markFeatureEncodeJson :: EncodeJson MarkFeature
-instance markFeatureDecodeJson :: DecodeJson MarkFeature
+EncodeJson MarkFeature
+DecodeJson MarkFeature
 ```
 
 #### `markFeatureDefault`
@@ -229,8 +229,8 @@ data MagicType
 
 ##### Instances
 ``` purescript
-instance magicTypeEncodeJson :: EncodeJson MagicType
-instance magicTypeDecodeJson :: DecodeJson MagicType
+EncodeJson MagicType
+DecodeJson MagicType
 ```
 
 #### `MagicTypeFeatureRec`
@@ -248,8 +248,8 @@ newtype MagicTypeFeature
 
 ##### Instances
 ``` purescript
-instance magicTypeFeatureEncodeJson :: EncodeJson MagicTypeFeature
-instance magicTypeFeatureDecodeJson :: DecodeJson MagicTypeFeature
+EncodeJson MagicTypeFeature
+DecodeJson MagicTypeFeature
 ```
 
 #### `magicTypeFeatureDefault`

--- a/docs/Echarts/Tooltip.md
+++ b/docs/Echarts/Tooltip.md
@@ -10,8 +10,8 @@ data TooltipTrigger
 
 ##### Instances
 ``` purescript
-instance tooltipTriggerEncodeJson :: EncodeJson TooltipTrigger
-instance tooltipTriggerDecodeJson :: DecodeJson TooltipTrigger
+EncodeJson TooltipTrigger
+DecodeJson TooltipTrigger
 ```
 
 #### `TooltipPosition`
@@ -24,8 +24,8 @@ data TooltipPosition
 
 ##### Instances
 ``` purescript
-instance tooltipPositionEncodeJson :: EncodeJson TooltipPosition
-instance tooltipPositionDecodeJson :: DecodeJson TooltipPosition
+EncodeJson TooltipPosition
+DecodeJson TooltipPosition
 ```
 
 #### `TooltipAxisPointerType`
@@ -40,8 +40,8 @@ data TooltipAxisPointerType
 
 ##### Instances
 ``` purescript
-instance tooltipAxisPointerTypeEncodeJson :: EncodeJson TooltipAxisPointerType
-instance tooltiopAxisPointerTypeDecodeJson :: DecodeJson TooltipAxisPointerType
+EncodeJson TooltipAxisPointerType
+DecodeJson TooltipAxisPointerType
 ```
 
 #### `TooltipAxisPointerRec`
@@ -59,8 +59,8 @@ newtype TooltipAxisPointer
 
 ##### Instances
 ``` purescript
-instance tooltipAxisPointerEncodeJson :: EncodeJson TooltipAxisPointer
-instance tooltipAxisPointerDecodeJson :: DecodeJson TooltipAxisPointer
+EncodeJson TooltipAxisPointer
+DecodeJson TooltipAxisPointer
 ```
 
 #### `tooltipAxisPointerDefault`
@@ -84,8 +84,8 @@ newtype Tooltip
 
 ##### Instances
 ``` purescript
-instance tooltipEncodeJson :: EncodeJson Tooltip
-instance tooltipDecodeJson :: DecodeJson Tooltip
+EncodeJson Tooltip
+DecodeJson Tooltip
 ```
 
 #### `tooltipDefault`

--- a/example/Chord2.purs
+++ b/example/Chord2.purs
@@ -6,9 +6,9 @@ import Data.Array hiding (init)
 import Data.String (indexOf, replace)
 import Data.Tuple.Nested
 import Data.Either
-import Data.Maybe 
+import Data.Maybe
 import qualified Data.StrMap as M
-import Control.Alt 
+import Control.Alt
 
 
 import ECharts.Chart

--- a/example/Connect.purs
+++ b/example/Connect.purs
@@ -156,7 +156,7 @@ options2 = Option $ optionDefault {
       }
     ]
   }
-           
+
 conn first second = do
   connect first second
   connect second first
@@ -165,7 +165,7 @@ conn first second = do
 connectM firstId secondId = do
   mbElFst <- getElementById firstId
   mbElSnd <- getElementById secondId
-  
+
   case Tuple mbElFst mbElSnd  of
     Tuple Nothing _ -> log "incorrect first id in connect"
     Tuple _ Nothing -> log "incorrect second id in connect"

--- a/example/EventRiver1.purs
+++ b/example/EventRiver1.purs
@@ -133,14 +133,14 @@ options dateDefault = Option $ optionDefault {
                ]
              }
           ]
-        
+
         }
       }
 
     ]
   }
 
-                    
+
 eventRiver id = do
   mbEl <- getElementById id
   case mbEl of
@@ -148,5 +148,5 @@ eventRiver id = do
     Just el -> do
       d <- D.now
       chart <- init Nothing el >>= setOption (options d) true
-  
+
       return unit

--- a/example/Events.purs
+++ b/example/Events.purs
@@ -4,12 +4,12 @@ import Prelude
 import Control.Monad.Eff.Console (print, CONSOLE())
 import Math hiding (log)
 import Data.Array hiding (init)
-import Data.Maybe 
+import Data.Maybe
 
 import Control.Monad.Eff
 import Control.Monad.Eff.Random
 
-import Utils 
+import Utils
 
 import ECharts.Chart
 import ECharts.Events
@@ -30,7 +30,7 @@ import qualified  ECharts.DataZoom as Zoom
 simpleData = Value <<< Simple
 
 lineData :: Eff _ (Array Number)
-lineData = do 
+lineData = do
   lst <- randomLst 30.0
   return $ (\x -> round $ x * 30.0 + 30.0 ) <$> lst
 
@@ -76,7 +76,7 @@ options_ line bar = Option $ optionDefault {
   xAxis = Just $ OneAxis $ Axis $ axisDefault {
     "type" = Just CategoryAxis,
     boundaryGap = Just $ CatBoundaryGap true,
-    "data" = Just $ (\i -> CommonAxisData $ "2013-03-" <> show i) <$> (1..30) 
+    "data" = Just $ (\i -> CommonAxisData $ "2013-03-" <> show i) <$> (1..30)
     },
   yAxis = Just $ OneAxis $ Axis $ axisDefault {"type" = Just ValueAxis},
   series = Just $ Just <$> [
@@ -92,7 +92,7 @@ options_ line bar = Option $ optionDefault {
   }
 
 
-options :: Eff _ _ 
+options :: Eff _ _
 options = do
   line <- lineData
   bar <- barData
@@ -101,7 +101,7 @@ options = do
 foreign import log :: forall a e. a -> Eff e Unit
 
 
-subscribe chart = do 
+subscribe chart = do
   let sub = \et hndl -> listen et hndl chart
   sub ClickEvent log
   sub DoubleClickEvent log
@@ -112,14 +112,14 @@ subscribe chart = do
 
 
 events id = do
-  mbEl <- getElementById id 
+  mbEl <- getElementById id
   case mbEl of
     Nothing -> print "incorrect id in events"
-    Just el -> do 
+    Just el -> do
       opts <- options
       chart <- init Nothing el
                >>= setOption opts true
-  
+
       subscribe chart
       return unit
 

--- a/example/Funnel2.purs
+++ b/example/Funnel2.purs
@@ -32,7 +32,7 @@ options = Option $ optionDefault {
         }
      ]
   }
-                    
+
 
 funnel2 id = do
   mbEl <- getElementById id

--- a/example/Gauge4.purs
+++ b/example/Gauge4.purs
@@ -55,4 +55,4 @@ gauge4 id = do
         os <- opts
         setOption os true chart
         return unit
-           
+

--- a/example/K.purs
+++ b/example/K.purs
@@ -1,6 +1,6 @@
 module K where
 
-import Prelude 
+import Prelude
 import Control.Monad.Eff.Console (print)
 import Data.Array hiding (init)
 import Data.Tuple

--- a/example/Map11.purs
+++ b/example/Map11.purs
@@ -44,9 +44,9 @@ option = Option $ optionDefault {
                  {name: "trololo", value: 123.0}
                  ]
               }
-            
+
           },
-       
+
 
        mapSeries: mapSeriesDefault{
          "data" = Just [],

--- a/example/Mix2Safe.purs
+++ b/example/Mix2Safe.purs
@@ -109,10 +109,10 @@ series = [
 
       }
     }
-  
+
   ]
-         
-         
+
+
 options :: Option
 options = Option $ optionDefault {
   tooltip = Just $ Tooltip tooltipDefault {trigger = Just TriggerAxis},
@@ -162,7 +162,7 @@ options = Option $ optionDefault {
               "Google",
               "must be",
               "other"]
-             
+
     },
   xAxis = Just $ OneAxis $ Axis $ axisDefault {
     "type" = Just CategoryAxis,
@@ -178,7 +178,7 @@ options = Option $ optionDefault {
      position = Just RightAxis
      },
    series = Just $ Just <$> series
-  
+
    }
 
 

--- a/example/Scatter3.purs
+++ b/example/Scatter3.purs
@@ -22,7 +22,7 @@ import qualified Utils as U
 showIt = {show: true}
 
 
-sinData = do 
+sinData = do
   randomIs <- U.randomLst 10000.0
   randomXs <- U.randomLst 10000.0
   let randoms = zipWith (\i x -> Tuple (U.precise 3.0 $ i * 10.0) x)  randomIs randomXs
@@ -35,7 +35,7 @@ cosData = do
   randomIs <- U.randomLst 10000.0
   randomXs <- U.randomLst 10000.0
   let randoms = zipWith (\i x -> Tuple (U.precise 3.0 $ i * 10.0) x)  randomIs randomXs
-  let mapfn = \(Tuple i rnd) -> 
+  let mapfn = \(Tuple i rnd) ->
         Tuple i (U.precise 3.0 $ cos i - i * (if i % 2.0 > 0.0 then 0.1 else -0.1) * rnd)
   return $ mapfn <$> randoms
 
@@ -45,7 +45,7 @@ simpleData (Tuple a b) = Value $ XYR {
   r: Nothing
   }
 
-options :: Eff _ _ 
+options :: Eff _ _
 options = do
   sines <- sinData
   coses <- cosData

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,8 +5,9 @@ var gulp = require('gulp')
 , run = require('gulp-run')
 , sequence = require('run-sequence')
 , jsValidate = require('gulp-jsvalidate')
+, trimlines = require("gulp-trimlines")
 , rename = require('gulp-rename')
-; 
+;
 
 require("./gulp/serve.js")();
 require("./gulp/runner.js")("runner", "Main");
@@ -94,6 +95,13 @@ gulp.task("lib", function() {
     });
 });
 
+gulp.task("trim-whitespace", function () {
+  var options = { leading: false };
+  return gulp.src(sources.concat(exampleSources), {base: "./"})
+            .pipe(trimlines(options))
+            .pipe(gulp.dest("."));
+});
+
 gulp.task("make", ["runner"], function() {
     return purescript.psc({
         src: sources.concat(exampleSources),
@@ -124,7 +132,7 @@ gulp.task("concat", ["browserify"], function() {
         .pipe(concat("build.js"))
         .pipe(gulp.dest("public"));
 });
-            
+
 
 gulp.task('psci', function() {
     return purescript.psci({

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "devDependencies": {
     "ecstatic": "^0.5.8",
     "express": "^4.11.0",
-    "gulp": "^3.8.10",
+    "gulp": "^3.9.0",
     "gulp-browserify": "^0.5.1",
     "gulp-concat": "^2.4.3",
     "gulp-jsvalidate": "^1.0.1",
     "gulp-livereload": "^3.4.0",
-    "gulp-purescript": "^0.6.0",
+    "gulp-purescript": "^0.8.0",
     "gulp-rename": "^1.2.0",
     "gulp-run": "^1.6.6",
+    "gulp-trimlines": "^1.0.0",
     "run-sequence": "^1.0.2"
   }
 }

--- a/src/ECharts/AddData.purs
+++ b/src/ECharts/AddData.purs
@@ -10,7 +10,6 @@ import Data.Function
 import Data.Maybe
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
-import Data.Argonaut.Combinators
 
 
 import ECharts.Chart
@@ -18,7 +17,7 @@ import ECharts.Item.Data
 import ECharts.Effects
 
 
-type AdditionalDataRec = 
+type AdditionalDataRec =
   {
     idx :: Number,
     datum :: ItemData,

--- a/src/ECharts/Axis.purs
+++ b/src/ECharts/Axis.purs
@@ -5,7 +5,7 @@ import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple())
 import Data.StrMap hiding (toList)
 import Data.Maybe
 import Data.Either
@@ -14,12 +14,10 @@ import Control.Alt ((<|>))
 import Data.List (toList)
 
 import ECharts.Common
-import ECharts.Coords
 import ECharts.Color
 import ECharts.Style.Line
 import ECharts.Style.Text
 import ECharts.Style.Area
-import ECharts.Symbol
 import ECharts.Formatter
 
 
@@ -58,7 +56,7 @@ type AxisLineRec = {
     }
 
 newtype AxisLine = AxisLine AxisLineRec
-   
+
 instance axisLineEncodeJson :: EncodeJson AxisLine where
   encodeJson (AxisLine a) = fromObject $ fromList $ toList [
     "show" := a.show,
@@ -77,7 +75,7 @@ instance axisLineDecodeJson :: DecodeJson AxisLine where
          (o .? "onZero")
     pure $ AxisLine r
 
-axisLineDefault :: AxisLineRec                            
+axisLineDefault :: AxisLineRec
 axisLineDefault = {
   show: Nothing,
   onZero: Nothing,
@@ -96,7 +94,7 @@ type AxisTickRec = {
     }
 
 newtype AxisTick = AxisTick AxisTickRec
-   
+
 instance axisTickEncodeJson :: EncodeJson AxisTick where
   encodeJson (AxisTick a) = fromObject $ fromList $ toList [
     "show" := a.show,
@@ -126,8 +124,8 @@ instance axisTickDecodeJson :: DecodeJson AxisTick where
          (o .? "onGap") <*>
          (o .? "interval")
     pure $ AxisTick r
-         
-                            
+
+
 axisTickDefault :: AxisTickRec
 axisTickDefault = {
   show: Nothing,
@@ -150,7 +148,7 @@ type AxisLabelRec =  {
     }
 
 newtype AxisLabel = AxisLabel AxisLabelRec
-  
+
 instance axisLabelEncodeJson :: EncodeJson AxisLabel  where
   encodeJson (AxisLabel a) = fromObject $ fromList $ toList [
     "show" := a.show,
@@ -180,7 +178,7 @@ instance axisLabelDecodeJson :: DecodeJson AxisLabel where
          (o .? "margin") <*>
          (o .? "clickable")
     pure $ AxisLabel r
-                             
+
 axisLabelDefault :: AxisLabelRec
 axisLabelDefault = {
   show: Nothing,
@@ -214,7 +212,7 @@ type AxisSplitLineRec = {
     }
 
 newtype AxisSplitLine = AxisSplitLine AxisSplitLineRec
-   
+
 instance axisSplitLineEncodeJson :: EncodeJson AxisSplitLine where
   encodeJson (AxisSplitLine obj) =
     fromObject $ fromList $ toList
@@ -251,7 +249,7 @@ type AxisSplitAreaRec =  {
 
 
 newtype AxisSplitArea = AxisSplitArea AxisSplitAreaRec
-  
+
 instance axisSplitAreaEncodeJson :: EncodeJson AxisSplitArea where
   encodeJson (AxisSplitArea obj) =
     fromObject $ fromList $ toList
@@ -271,7 +269,7 @@ instance axisSplitAreaDecodeJson :: DecodeJson AxisSplitArea where
          (o .? "onGap") <*>
          (o .? "areaStyle")
     pure $ AxisSplitArea r
-          
+
 
 axisSplitAreaDefault :: AxisSplitAreaRec
 axisSplitAreaDefault = {
@@ -280,7 +278,7 @@ axisSplitAreaDefault = {
   areaStyle: Nothing
   }
 
-  
+
 data AxisType = CategoryAxis | ValueAxis | TimeAxis
 instance axisTypeEncodeJson :: EncodeJson AxisType where
   encodeJson a = encodeJson $ case a of
@@ -330,7 +328,7 @@ instance axisNameLocationDecodeJson :: DecodeJson AxisNameLocation where
       "start" -> pure Start
       "end" -> pure End
       _ -> Left "incorrect axis name location"
-      
+
 
 
 type CustomAxisDataRec = {
@@ -343,7 +341,7 @@ data AxisData = CommonAxisData String
 instance axisDataEncodeJson :: EncodeJson AxisData where
   encodeJson (CommonAxisData name) = fromString name
   encodeJson (CustomAxisData obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "value" := obj.value,
       "textStyle" := obj.textStyle
@@ -486,7 +484,7 @@ type PolarNameRec = {
     }
 
 newtype PolarName = PolarName PolarNameRec
-   
+
 instance polarNameEncode :: EncodeJson PolarName where
   encodeJson (PolarName obj) =
     fromObject $ fromList $ toList
@@ -561,9 +559,9 @@ instance indicatorDecodeJson :: DecodeJson Indicator where
          (o .? "max") <*>
          (o .? "axisLabel")
     pure $ Indicator r
-         
 
-    
+
+
 indicatorDefault :: IndicatorRec
 indicatorDefault = {
   text: Nothing,

--- a/src/ECharts/Color.purs
+++ b/src/ECharts/Color.purs
@@ -12,7 +12,6 @@ import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 
 import ECharts.Item.Value
-import ECharts.Utils
 
 type Color = String
 

--- a/src/ECharts/Common.purs
+++ b/src/ECharts/Common.purs
@@ -12,7 +12,6 @@ import Data.Array ((!!))
 import Data.List (toList)
 
 import qualified Data.String as S
-import Data.Function
 import Data.Tuple
 import qualified Data.StrMap as M
 import Global
@@ -89,7 +88,7 @@ instance selModeDecodeJson :: DecodeJson SelectedMode where
         if not fls
           then pure SelModeFalse
           else Left "incorrect select mode")
-          
+
 
 
 data MapValueCalculation = SumCalculation | AverageCalculation
@@ -127,7 +126,7 @@ instance roamDecodeJson :: DecodeJson Roam where
         if bl
           then pure Enable
           else pure Disable)
-          
+
 
 type MinMaxRec = {
   min :: Number,

--- a/src/ECharts/Connect.purs
+++ b/src/ECharts/Connect.purs
@@ -14,5 +14,5 @@ foreign import connectImpl :: forall e. Fn2 EChart EChart (Eff (connect::CONNECT
 connect :: forall e. EChart -> EChart -> Eff (connect::CONNECT|e) Connection
 connect target source = do
   runFn2 connectImpl target source
-    
+
 

--- a/src/ECharts/Coords.purs
+++ b/src/ECharts/Coords.purs
@@ -16,7 +16,7 @@ data XPos = XLeft
           | XRight
           | XCenter
           | X Number
-            
+
 instance xPosEncodeJson :: EncodeJson XPos where
   encodeJson XLeft = fromString "left"
   encodeJson XRight = fromString "right"
@@ -39,7 +39,7 @@ data YPos = YTop
           | YBottom
           | YCenter
           | Y Number
-            
+
 instance yPosEncodeJson :: EncodeJson YPos where
   encodeJson ypos = case ypos of
     YTop -> fromString "top"
@@ -62,7 +62,7 @@ data LabelPosition = LPOuter | LPInner | LPTop | LPRight | LPLeft | LPBottom
                    | LPInsideLeft | LPInsideRight | LPInsideTop | LPInsideBottom
 
 instance labelPositionEncodeJson :: EncodeJson LabelPosition where
-  encodeJson a = encodeJson $ case a of 
+  encodeJson a = encodeJson $ case a of
     LPOuter -> "outer"
     LPInner -> "inner"
     LPTop -> "top"
@@ -90,6 +90,7 @@ instance labelPositionDecodeJson :: DecodeJson LabelPosition where
       "insideRight" -> pure LPInsideRight
       "insideTop" -> pure LPInsideTop
       "insideBottom" -> pure LPInsideBottom
+      _ -> Left "Invalid LabelPosition"
 
 
 data HorizontalAlign = HAlignLeft
@@ -97,7 +98,7 @@ data HorizontalAlign = HAlignLeft
                      | HAlignCenter
 
 instance textAlignEncodeJson :: EncodeJson HorizontalAlign where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     HAlignLeft -> "left"
     HAlignRight -> "right"
     HAlignCenter -> "center"

--- a/src/ECharts/DataRange.purs
+++ b/src/ECharts/DataRange.purs
@@ -43,11 +43,11 @@ type DataRangeRec = {
     }
 
 newtype DataRange = DataRange DataRangeRec
-   
+
 
 instance dataRangeEncodeJson :: EncodeJson DataRange where
   encodeJson (DataRange obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "show" := obj.show,
       "orient" := obj.orient,

--- a/src/ECharts/DataZoom.purs
+++ b/src/ECharts/DataZoom.purs
@@ -32,11 +32,11 @@ type DataZoomRec = {
     }
 
 newtype DataZoom = DataZoom DataZoomRec
-   
+
 
 instance dataZoomEncodeJson :: EncodeJson DataZoom where
   encodeJson (DataZoom obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "show" := obj.show,
       "orient" := obj.orient,

--- a/src/ECharts/Effects.purs
+++ b/src/ECharts/Effects.purs
@@ -18,7 +18,7 @@ foreign import data DISCONNECT :: !
 foreign import data LISTEN :: !
 foreign import data UNLISTEN :: !
 
-foreign import data IMAGE_MAKING :: !                    
+foreign import data IMAGE_MAKING :: !
 
 foreign import data LOADING_SHOW :: !
 foreign import data LOADING_HIDE :: !

--- a/src/ECharts/Events.purs
+++ b/src/ECharts/Events.purs
@@ -36,7 +36,7 @@ type EventParam = Json
 newtype Sub = Sub (forall eff. Eff (unlisten :: UNLISTEN|eff) Unit)
 
 eventStr :: EventType -> String
-eventStr event = case event of 
+eventStr event = case event of
   RefreshEvent -> "refresh"
   RestoreEvent -> "restore"
   ResizeEvent -> "resize"
@@ -54,17 +54,17 @@ eventStr event = case event of
   DataViewChangedEvent -> "dataViewChanged"
   MapRoamEvent -> "mapRoam"
   MagicTypeChangedEvent -> "magicTypeChanged"
-  
-                 
+
+
 
 foreign import listenImpl :: forall e.
                              Fn3 String
-                             (EventParam -> Eff (listen::LISTEN|e) Unit) 
-                             EChart 
+                             (EventParam -> Eff (listen::LISTEN|e) Unit)
+                             EChart
                              (Eff (listen::LISTEN|e) Sub)
 
 listen :: forall e.
           EventType ->
-          (EventParam -> Eff (listen :: LISTEN|e) Unit) -> 
+          (EventParam -> Eff (listen :: LISTEN|e) Unit) ->
           EChart -> Eff (listen :: LISTEN|e) Sub
 listen eventName handler chart = runFn3 listenImpl (eventStr eventName) handler chart

--- a/src/ECharts/Formatter.purs
+++ b/src/ECharts/Formatter.purs
@@ -4,22 +4,14 @@ module ECharts.Formatter(
   ) where
 
 import Prelude
-import Data.Maybe
-import Data.StrMap (fromList, StrMap (..))
-import Data.Tuple
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
-import Data.Argonaut.Combinators
 
 
 import Data.Function
 
 import Control.Monad.Eff
-
-import ECharts.Utils
-import ECharts.Common
-import ECharts.Item.Value
 
 type FormatParams = Json
 
@@ -31,7 +23,7 @@ data Formatter =
 foreign import func2json :: forall a. a -> Json
 
 foreign import effArrToFn :: forall eff a b. (a -> Eff eff b) -> Fn1 a b
-                
+
 instance formatterEncodeJson :: EncodeJson Formatter where
   encodeJson (Template str) = encodeJson str
   encodeJson (FormatFunc func) = func2json $ effArrToFn func

--- a/src/ECharts/Grid.purs
+++ b/src/ECharts/Grid.purs
@@ -25,11 +25,11 @@ type GridRec = {
     }
 
 newtype Grid = Grid GridRec
-   
+
 
 instance gridEncodeJson :: EncodeJson Grid where
   encodeJson (Grid obj) =
-    fromObject $ fromList $ toList 
+    fromObject $ fromList $ toList
     [
       "x" := obj.x,
       "y" := obj.y,

--- a/src/ECharts/Image.purs
+++ b/src/ECharts/Image.purs
@@ -8,7 +8,6 @@ import DOM
 import DOM.Node.Types
 import Control.Monad.Eff
 import Data.Function
-import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Either

--- a/src/ECharts/Item/Data.purs
+++ b/src/ECharts/Item/Data.purs
@@ -43,7 +43,7 @@ instance itemDataEncodeJson :: EncodeJson ItemData where
     ["name" := name]
 
 instance itemDataDecodeJson :: DecodeJson ItemData where
-  decodeJson json = 
+  decodeJson json =
     (do obj <- decodeJson json
         val <- obj .? "value"
         name <- obj .? "name"
@@ -63,7 +63,7 @@ instance itemDataDecodeJson :: DecodeJson ItemData where
     (Label <$> (decodeJson json >>= (.? "name")))
     <|>
     (Value <$> (decodeJson json))
-    
+
 
 
 dataDefault :: ItemValue -> ItemDataDatRec

--- a/src/ECharts/Item/Value.purs
+++ b/src/ECharts/Item/Value.purs
@@ -2,12 +2,9 @@ module ECharts.Item.Value where
 
 import Prelude
 import Data.Maybe
-import Data.Array (length)
 import Data.Either (Either(..))
 import Control.Alt ((<|>))
-import Data.Argonaut.Core
 import Data.Argonaut.Encode
-import Data.Argonaut.Combinators
 import Data.Argonaut.Decode
 import Data.List (toList, fromList, List(..))
 
@@ -29,7 +26,7 @@ instance itemValueEncodeJson :: EncodeJson ItemValue where
                                  [encodeJson x, encodeJson y, encodeJson r]
     HLOC {h = h, l = l, o = o, c = c} -> encodeJson [o, c, l, h]
 
-  
+
 instance itemValueDecodeJson :: DecodeJson ItemValue where
   decodeJson json =
     (do arr <- decodeJson json

--- a/src/ECharts/Legend.purs
+++ b/src/ECharts/Legend.purs
@@ -36,7 +36,7 @@ instance legendItemDecodeJson :: DecodeJson LegendItem where
     o <- decodeJson j
     name <- (o .? "name")
     r <- {icon: _, textStyle: _} <$> (o .? "icon") <*> (o .? "textStyle")
-    pure $ LegendItem name r 
+    pure $ LegendItem name r
 
 legendItemDefault :: String -> LegendItem
 legendItemDefault name = LegendItem name {icon: Nothing, textStyle: Nothing}
@@ -140,4 +140,4 @@ instance legendDecodeJson :: DecodeJson Legend where
          (o .? "selected") <*>
          (o .? "data")
     pure $ Legend r
-         
+

--- a/src/ECharts/Loading.purs
+++ b/src/ECharts/Loading.purs
@@ -5,20 +5,17 @@ module ECharts.Loading (
   loadingOptionDefault,
   showLoading,
   hideLoading
-  ) where 
+  ) where
 
 import Prelude
-import ECharts.Common
 import ECharts.Coords
 import ECharts.Chart
 import ECharts.Style.Text
 import ECharts.Effects
 import ECharts.Utils
 
-import Data.Array (concat)
 import Data.Function
 import Data.Maybe
-import Data.Tuple.Nested
 import qualified Data.StrMap as M
 import Control.Monad.Eff
 import Data.List (toList)
@@ -37,7 +34,7 @@ instance loadingEffectEncodeJson :: EncodeJson LoadingEffect where
     Ring -> "ring"
     Whirling -> "whirling"
     DynamicLine -> "dynamicLine"
-    Bubble -> "bubble"    
+    Bubble -> "bubble"
 
 type LoadingOptionRec = {
     text :: Maybe String,
@@ -50,7 +47,7 @@ type LoadingOptionRec = {
     }
 
 newtype LoadingOption = LoadingOption LoadingOptionRec
-   
+
 instance showLoadingOptions :: EncodeJson LoadingOption where
   encodeJson (LoadingOption options) =
     fromObject $ M.fromList $ toList [
@@ -64,7 +61,7 @@ instance showLoadingOptions :: EncodeJson LoadingOption where
       ]
 
 
-foreign import showLoadingImpl :: forall e a. Fn2 Json EChart (Eff (showLoadingECharts::LOADING_SHOW|e) EChart)
+foreign import showLoadingImpl :: forall e. Fn2 Json EChart (Eff (showLoadingECharts::LOADING_SHOW|e) EChart)
 
 showLoading :: forall e. LoadingOption -> EChart ->
                Eff (showLoadingECharts::LOADING_SHOW|e) EChart

--- a/src/ECharts/Mark/Data.purs
+++ b/src/ECharts/Mark/Data.purs
@@ -2,8 +2,7 @@ module ECharts.Mark.Data where
 
 import Prelude
 import Data.Maybe
-import Data.StrMap (fromList, StrMap (..))
-import Data.Tuple
+import Data.StrMap (fromList)
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
@@ -21,7 +20,7 @@ type MarkPointDataRec = {
   }
 
 newtype MarkPointData = MarkPointData MarkPointDataRec
-   
+
 instance mpDataEncodeJson :: EncodeJson MarkPointData where
   encodeJson (MarkPointData mp) =
     fromObject $ fromList $ toList
@@ -53,8 +52,8 @@ instance mpDataDecodeJson :: DecodeJson MarkPointData where
          (o .? "yAxis") <*>
          (o .? "type")
     pure $ MarkPointData r
-           
-    
+
+
 markPointDataDefault :: MarkPointDataRec
 markPointDataDefault =
   {

--- a/src/ECharts/Mark/Effect.purs
+++ b/src/ECharts/Mark/Effect.purs
@@ -6,8 +6,7 @@ import Data.Argonaut.Core
 import Data.Argonaut.Combinators
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
-import Data.StrMap (fromList, StrMap(..))
-import ECharts.Common
+import Data.StrMap (fromList)
 import ECharts.Color
 import Data.List (toList)
 
@@ -21,7 +20,7 @@ type MarkPointEffectRec = {
   }
 
 newtype MarkPointEffect = MarkPointEffect MarkPointEffectRec
- 
+
 instance mpEffectEncodeJson :: EncodeJson MarkPointEffect where
   encodeJson (MarkPointEffect cfg) =
     fromObject $ fromList $ toList

--- a/src/ECharts/Mark/Line.purs
+++ b/src/ECharts/Mark/Line.purs
@@ -19,7 +19,7 @@ import Data.Maybe
 import Control.Monad.Eff
 import Data.Function
 
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList)
 import Data.Tuple
 import Data.List (toList)
 import Data.Argonaut.Core
@@ -38,7 +38,7 @@ type MarkLineRec = {
   }
 
 newtype MarkLine = MarkLine MarkLineRec
-   
+
 
 instance mlEncodeJson :: EncodeJson MarkLine where
   encodeJson (MarkLine ml) =
@@ -71,7 +71,7 @@ instance mlDecodeJson :: DecodeJson MarkLine where
          (o .? "data") <*>
          (o .? "itemStyle")
     pure $ MarkLine r
-           
+
 
 markLineDefault :: MarkLineRec
 markLineDefault =
@@ -89,7 +89,7 @@ markLineDefault =
 foreign import addMarkLineImpl :: forall e. Fn2 Json EChart (Eff (addMarkLineECharts::ADD_MARKLINE|e) EChart)
 
 
-addMarkLine :: forall e a. MarkLine  -> EChart -> 
+addMarkLine :: forall e. MarkLine  -> EChart ->
                Eff (addMarkLineECharts::ADD_MARKLINE|e) EChart
 addMarkLine ml chart = runFn2 addMarkLineImpl (encodeJson ml) chart
 
@@ -99,7 +99,7 @@ addMarkLine ml chart = runFn2 addMarkLineImpl (encodeJson ml) chart
 foreign import delMarkLineImpl :: forall e. Fn3 Number String EChart
        (Eff (removeMarkLine::REMOVE_MARKLINE|e) EChart)
 
-delMarkLine :: forall e. Number -> String -> EChart -> 
+delMarkLine :: forall e. Number -> String -> EChart ->
                Eff (removeMarkLine::REMOVE_MARKLINE|e) EChart
 delMarkLine idx name chart = runFn3 delMarkLineImpl idx name chart
 

--- a/src/ECharts/Mark/Point.purs
+++ b/src/ECharts/Mark/Point.purs
@@ -8,7 +8,6 @@ module ECharts.Mark.Point (
 
 import Prelude
 import ECharts.Chart
-import ECharts.Common
 import ECharts.Symbol
 import ECharts.Mark.Effect
 import ECharts.Mark.Data
@@ -18,7 +17,7 @@ import Data.Maybe
 import Control.Monad.Eff
 import Data.Function
 
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList, StrMap ())
 import Data.List (toList)
 import Data.Tuple
 import Data.Argonaut.Core
@@ -36,7 +35,7 @@ type MarkPointRec = {
   }
 
 newtype MarkPoint = MarkPoint MarkPointRec
-   
+
 
 instance markPointEncodeJson :: EncodeJson MarkPoint where
   encodeJson (MarkPoint mp) =
@@ -81,12 +80,12 @@ markPointDefault =
 foreign import delMarkPointImpl :: forall e. Fn3 Number String EChart
        (Eff (removeMarkPointECharts::REMOVE_MARKPOINT|e) EChart)
 
-delMarkPoint :: forall e. Number -> String -> EChart -> 
+delMarkPoint :: forall e. Number -> String -> EChart ->
                 (Eff (removeMarkPointECharts::REMOVE_MARKPOINT|e) EChart)
-delMarkPoint idx name chart = runFn3 delMarkPointImpl idx name chart 
-  
+delMarkPoint idx name chart = runFn3 delMarkPointImpl idx name chart
+
 foreign import addMarkPointImpl :: forall e. Fn2 Json EChart (Eff (addMarkPointECharts::ADD_MARKPOINT|e) EChart)
 
-addMarkPoint :: forall e. MarkPoint -> EChart -> 
+addMarkPoint :: forall e. MarkPoint -> EChart ->
                 (Eff (addMarkPointECharts::ADD_MARKPOINT|e) EChart)
 addMarkPoint mp chart = runFn2 addMarkPointImpl (encodeJson mp) chart

--- a/src/ECharts/Options.purs
+++ b/src/ECharts/Options.purs
@@ -36,7 +36,7 @@ import ECharts.Effects
      Option{series = Just [Nothing,
         Just $ SomeSeries
                  universalSeriesDefault{tooltip = Just myTooltip}
-                 someSeriesDefault 
+                 someSeriesDefault
        }
    It will erase all series data if we use [] as zero in updating
    i.e. legend.
@@ -66,7 +66,7 @@ type OptionRec = {
     }
 
 newtype Option = Option OptionRec
-   
+
 
 instance optionsEncodeJson :: EncodeJson Option where
   encodeJson (Option opts) =
@@ -77,7 +77,7 @@ instance optionsEncodeJson :: EncodeJson Option where
       "renderAsImage" := opts.renderAsImage,
       "calculable" := opts.calculable,
       "animation" := opts.animation,
-      
+
       "series" := opts.series,
 
       "timeline" := opts.timeline,
@@ -134,7 +134,7 @@ instance optionsDecodeJson :: DecodeJson Option where
          (obj .? "yAxis") <*>
          (obj .? "polar")
     pure $ Option r
-         
+
 
 optionDefault :: OptionRec
 optionDefault = {
@@ -166,6 +166,6 @@ setOption :: forall e.
              Boolean ->
              EChart ->
              Eff (echartSetOption::ECHARTS_OPTION_SET|e) EChart
-setOption opts notMerge chart = runFn3 setOptionImpl 
+setOption opts notMerge chart = runFn3 setOptionImpl
                                 (unnull <<< encodeJson $ opts) notMerge chart
 

--- a/src/ECharts/RoamController.purs
+++ b/src/ECharts/RoamController.purs
@@ -31,7 +31,7 @@ type RoamControllerRec = {
     }
 
 newtype RoamController = RoamController RoamControllerRec
-   
+
 instance roamControllerEncodeJson :: EncodeJson RoamController where
   encodeJson (RoamController obj) =
     fromObject $ fromList $ toList
@@ -81,7 +81,7 @@ instance roamControllerDecodeJson :: DecodeJson RoamController where
          (o .? "step") <*>
          (o .? "mapTypeControl")
     pure $ RoamController r
-    
+
 roamControllerDefault :: RoamControllerRec
 roamControllerDefault = {
   show: Nothing,

--- a/src/ECharts/Series.purs
+++ b/src/ECharts/Series.purs
@@ -27,7 +27,7 @@ module ECharts.Series (
   gaugeSeriesDefault,
   funnelSeriesDefault,
   eventRiverSeriesDefault
-  ) where 
+  ) where
 
 import Prelude
 import Control.Monad.Eff
@@ -38,7 +38,7 @@ import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple())
 import Data.StrMap hiding (toList)
 import Data.Array (concat)
 import Data.List (toList)
@@ -64,7 +64,7 @@ data ChartType = Line | Bar | Scatter | Candlestick | Pie | Radar
                | Chord | Force | Map | Gauge | Funnel | EventRiver
 
 instance chartTypeEncodeJson :: EncodeJson ChartType where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     Line -> "line"
     Bar -> "bar"
     Scatter -> "scatter"
@@ -84,7 +84,7 @@ data Series = LineSeries
               {common :: UniversalSeriesRec, barSeries ::  BarSeriesRec}
             | ScatterSeries
               {common :: UniversalSeriesRec, scatterSeries :: ScatterSeriesRec}
-            | CandlestickSeries 
+            | CandlestickSeries
               {common :: UniversalSeriesRec, candlestickSeries :: CandlestickSeriesRec}
             | PieSeries
               {common :: UniversalSeriesRec, pieSeries ::  PieSeriesRec}
@@ -348,8 +348,8 @@ decodeScatterSeriesRec o =
   (o .? "symbolRotate") <*>
   (o .? "large") <*>
   (o .? "largeThreshold") <*>
-  (o .? "legendHoverLink") 
-    
+  (o .? "legendHoverLink")
+
 
 
 type CandlestickSeriesRec = {
@@ -393,7 +393,7 @@ decodeCandleStickSeries o =
   (o .? "barMinHeight") <*>
   (o .? "barWidth") <*>
   (o .? "barMaxWidth")
-                                 
+
 type PieSeriesRec = {
   "data" ::Maybe (Array ItemData),
   center :: Maybe Center,
@@ -457,7 +457,7 @@ decodePieSeriesRec o =
   (o .? "selectedMode") <*>
   (o .? "legendHoverLink")
 
-                 
+
 type RadarSeriesRec = {
   "data" ::Maybe (Array ItemData),
 
@@ -500,7 +500,7 @@ decodeRadarSeriesRec o =
   (o .? "symbol" ) <*>
   (o .? "symbolSize") <*>
   (o .? "symbolRotate") <*>
-  (o .? "legendHoverLink") 
+  (o .? "legendHoverLink")
 
 type ChordSeriesRec = {
   nodes :: Maybe (Array Node),
@@ -594,7 +594,7 @@ decodeChordSeriesRec o =
   (o .? "sort") <*>
   (o .? "sortSub") <*>
   (o .? "clockWise")
-  
+
 
 type ForceSeriesRec = {
   categories :: Maybe (Array ForceCategory),
@@ -703,10 +703,10 @@ decodeForceSeriesRec o =
   (o .? "useWorker") <*>
   (o .? "steps") <*>
   (o .? "ribbonType")
-                      
+
 type MapSeriesRec = {
   "data" ::Maybe (Array ItemData),
-  
+
   selectedMode :: Maybe SelectedMode,
   mapType :: Maybe String,
   hoverable :: Maybe Boolean,
@@ -885,7 +885,7 @@ decodeGaugeSeriesRec o =
   (o .? "pointer") <*>
   (o .? "legendHoverLink") <*>
   (o .? "axisLabel")
-                      
+
 type FunnelSeriesRec = {
   "data" ::Maybe (Array ItemData),
 
@@ -904,7 +904,7 @@ type FunnelSeriesRec = {
   sort :: Maybe Sort,
   legendHoverLink :: Maybe Boolean
   }
-funnelSeriesDefault :: FunnelSeriesRec 
+funnelSeriesDefault :: FunnelSeriesRec
 funnelSeriesDefault = {
   "data": Nothing,
   x: Nothing,
@@ -973,7 +973,7 @@ decodeFunnelSeriesRec o =
   (o .? "gap") <*>
   (o .? "sort") <*>
   (o .? "legendHoverLink")
-                       
+
 type EventRiverSeriesRec = {
   eventList :: Maybe (Array OneEvent),
 
@@ -1062,7 +1062,8 @@ instance decodeSeries :: DecodeJson Series where
       "gauge" -> GaugeSeries <$> ({common: u, gaugeSeries: _} <$> decodeGaugeSeriesRec obj)
       "funnel" -> FunnelSeries <$> ({common: u, funnelSeries: _} <$> decodeFunnelSeriesRec obj)
       "eventRiver" -> EventRiverSeries <$> ({common: u, eventRiverSeries: _} <$> decodeEventRiverSeriesRec obj)
-      
+      _ -> Left "Invalid Series"
+
 
 foreign import setSeriesImpl :: forall e. Fn3 (Array Json) Boolean EChart (Eff e EChart)
 

--- a/src/ECharts/Series/EventRiver.purs
+++ b/src/ECharts/Series/EventRiver.purs
@@ -7,7 +7,7 @@ module ECharts.Series.EventRiver (
   OneEvent(..),
   OneEventRec(),
   oneEventDefault
-  ) where 
+  ) where
 
 import Prelude
 import Data.Maybe
@@ -16,25 +16,10 @@ import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
-import Data.Tuple (Tuple(..))
 import Data.StrMap hiding (toList)
 import Data.List (toList)
-import Data.Date (Date(..), JSDate(), toJSDate, fromStringStrict)
+import Data.Date (Date(), JSDate(), toJSDate, fromStringStrict)
 
-
-import ECharts.Common
-import ECharts.Coords
-import ECharts.Chart
-import ECharts.Tooltip
-import ECharts.Style.Item
-import ECharts.Mark.Line
-import ECharts.Mark.Point
-import ECharts.Item.Data
-import ECharts.Symbol
-import ECharts.Series.Force
-import ECharts.Series.Gauge
-import ECharts.Axis
-import ECharts.Title
 
 type EvolutionDetailRec = {
     link :: Maybe String,
@@ -43,7 +28,7 @@ type EvolutionDetailRec = {
     }
 
 newtype EvolutionDetail = EvolutionDetail EvolutionDetailRec
-   
+
 
 instance evoDetailEncodeJson :: EncodeJson EvolutionDetail where
   encodeJson (EvolutionDetail e) = fromObject $ fromList $ toList [
@@ -61,9 +46,9 @@ instance evoDetailDecodeJson :: DecodeJson EvolutionDetail where
          (o .? "link") <*>
          (o .? "text") <*>
          (o .? "img")
-    pure $ EvolutionDetail r 
+    pure $ EvolutionDetail r
 
-                                   
+
 evolutionDetailDefault :: EvolutionDetailRec
 evolutionDetailDefault = {
   link: Nothing,
@@ -79,7 +64,7 @@ type EvolutionRec = {
 
 newtype Evolution = Evolution EvolutionRec
 
-foreign import jsDateToJson :: JSDate -> Json 
+foreign import jsDateToJson :: JSDate -> Json
 
 dateToJson :: Date -> Json
 dateToJson = jsDateToJson <<< toJSDate
@@ -95,7 +80,7 @@ instance evoDecodeJson :: DecodeJson Evolution where
   decodeJson j = do
     o <- decodeJson j
     t <- o .? "time"
-    time <- maybe (Left "incorrect time") Right $ fromStringStrict t 
+    time <- maybe (Left "incorrect time") Right $ fromStringStrict t
     r <- { time: time
          , value: _
          , detail: _ } <$>
@@ -110,7 +95,7 @@ type OneEventRec = {
     }
 
 newtype OneEvent = OneEvent OneEventRec
-   
+
 oneEventDefault :: OneEventRec
 oneEventDefault = {
   name: Nothing,

--- a/src/ECharts/Series/Force.purs
+++ b/src/ECharts/Series/Force.purs
@@ -1,25 +1,17 @@
 module ECharts.Series.Force where
 
 import Prelude
-import Control.Monad.Eff
 import Control.Alt ((<|>))
-import Data.Function
 import Data.Maybe
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple())
 import Data.StrMap hiding (toList)
 import Data.List (toList)
 
-import ECharts.Common
-import ECharts.Coords
-import ECharts.Tooltip
 import ECharts.Style.Item
-import ECharts.Mark.Line
-import ECharts.Mark.Point
-import ECharts.Item.Data
 import ECharts.Symbol
 import ECharts.Series.Force
 
@@ -31,7 +23,7 @@ type ForceCategoryRec = {
     }
 
 newtype ForceCategory = ForceCategory ForceCategoryRec
-   
+
 forceCategoryDefault :: ForceCategoryRec
 forceCategoryDefault = {
   name: Nothing,
@@ -59,7 +51,7 @@ instance forceCategoryDecodeJson :: DecodeJson ForceCategory where
          (o .? "symbolSize") <*>
          (o .? "itemStyle")
     pure $ ForceCategory r
-           
+
 
 
 type NodeRec = {
@@ -145,7 +137,7 @@ data LinkEnd = Name String | Index Number
 
 instance linkEndEncodeJson :: EncodeJson LinkEnd where
   encodeJson (Name name) = encodeJson name
-  encodeJson (Index id) = encodeJson id 
+  encodeJson (Index id) = encodeJson id
 
 instance linkEndDecodeJson :: DecodeJson LinkEnd where
   decodeJson j =
@@ -155,7 +147,7 @@ type LinkRec = {
     source :: LinkEnd,
     target :: LinkEnd,
     weight :: Number,
-    itemStyle :: Maybe ItemStyle 
+    itemStyle :: Maybe ItemStyle
     }
 
 newtype Link = Link LinkRec

--- a/src/ECharts/Series/Gauge.purs
+++ b/src/ECharts/Series/Gauge.purs
@@ -1,23 +1,19 @@
 module ECharts.Series.Gauge where
 
-import Prelude 
-import Control.Monad.Eff
-import Data.Function
+import Prelude
 import Data.Maybe
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
-import Data.Tuple (Tuple(..))
+import Data.Tuple (Tuple())
 import Data.StrMap hiding (toList)
 import Data.List (toList)
 
 import ECharts.Common
-import ECharts.Coords
 import ECharts.Color
 import ECharts.Style.Line
 import ECharts.Style.Text
-import ECharts.Symbol
 import ECharts.Formatter
 
 type PointerRec = {
@@ -25,7 +21,7 @@ type PointerRec = {
     width :: Maybe Number,
     color :: Maybe Color
     }
-  
+
 newtype Pointer = Pointer PointerRec
 
 pointerDefault :: PointerRec
@@ -51,7 +47,7 @@ instance pointerDecodeJson :: DecodeJson Pointer where
          (o .? "length") <*>
          (o .? "width") <*>
          (o .? "color")
-    pure $ Pointer r 
+    pure $ Pointer r
 
 type SplitLineRec = {
     show :: Maybe Boolean,
@@ -100,7 +96,7 @@ type GaugeDetailRec = {
     }
 
 newtype GaugeDetail = GaugeDetail GaugeDetailRec
-   
+
 gaugeDetailDefault :: GaugeDetailRec
 gaugeDetailDefault = {
   show: Nothing,

--- a/src/ECharts/Style/Area.purs
+++ b/src/ECharts/Style/Area.purs
@@ -1,9 +1,7 @@
 module ECharts.Style.Area where
 
 import Prelude
-import Data.Maybe
-import Data.StrMap (fromList, StrMap (..))
-import Data.Tuple
+import Data.StrMap (fromList)
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
@@ -25,4 +23,4 @@ instance areaStyleEncodeJson :: EncodeJson AreaStyle where
 instance areaStyleDecodeJson :: DecodeJson AreaStyle where
   decodeJson j = do
     o <- decodeJson j
-    AreaStyle <$> (o .? "color") 
+    AreaStyle <$> (o .? "color")

--- a/src/ECharts/Style/Checkpoint.purs
+++ b/src/ECharts/Style/Checkpoint.purs
@@ -21,7 +21,7 @@ type CheckpointStyleRec = {
     }
 
 newtype CheckpointStyle = CheckpointStyle CheckpointStyleRec
-   
+
 
 instance checkpointStyleEncodeJson :: EncodeJson CheckpointStyle where
   encodeJson (CheckpointStyle obj) =
@@ -47,7 +47,7 @@ instance checkpointStyleDecodeJson :: DecodeJson CheckpointStyle where
          (o .? "borderColor") <*>
          (o .? "label")
     pure $ CheckpointStyle r
-    
+
 checkpointStyleDefault :: CheckpointStyleRec
 checkpointStyleDefault = {
   symbol: Nothing,

--- a/src/ECharts/Style/Chord.purs
+++ b/src/ECharts/Style/Chord.purs
@@ -2,12 +2,11 @@ module ECharts.Style.Chord where
 
 import Prelude
 import Data.Maybe
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList)
 import Data.List (toList)
-import Data.Tuple
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
-import Data.Argonaut.Decode 
+import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
 
 
@@ -21,7 +20,7 @@ type ChordStyleRec = {
   }
 
 newtype ChordStyle = ChordStyle ChordStyleRec
-   
+
 
 
 instance chordStyleJson :: EncodeJson ChordStyle where

--- a/src/ECharts/Style/Item.purs
+++ b/src/ECharts/Style/Item.purs
@@ -3,9 +3,7 @@ module ECharts.Style.Item where
 import Prelude
 import Data.Maybe
 import Data.List (toList)
-import Data.Either
-import Data.StrMap (fromList, StrMap (..))
-import Data.Tuple
+import Data.StrMap (fromList)
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
@@ -36,7 +34,7 @@ newtype ItemLabel = ItemLabel ItemLabelRec
 
 instance itemLabelEncodeJson :: EncodeJson ItemLabel where
   encodeJson (ItemLabel il) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "show" := il.show,
       "position" := il.position,
@@ -63,7 +61,7 @@ instance itemLabelDecodeJson :: DecodeJson ItemLabel where
          (o .? "rotate")
     pure $ ItemLabel r
 
-    
+
 itemLabelDefault :: ItemLabelRec
 itemLabelDefault = {
   show: Nothing,
@@ -85,7 +83,7 @@ newtype ItemLabelLine = ItemLabelLine ItemLabelLineRec
 
 instance itemLabelLineEncodeJson :: EncodeJson ItemLabelLine where
   encodeJson (ItemLabelLine ill) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "show" := ill.show,
       "length" := ill.length,
@@ -101,8 +99,8 @@ instance itemLabelLineDecodeJson :: DecodeJson ItemLabelLine where
          (o .? "show") <*>
          (o .? "length") <*>
          (o .? "lineStyle")
-    pure $ ItemLabelLine r 
-  
+    pure $ ItemLabelLine r
+
 itemLabelLineDefault :: ItemLabelLineRec
 itemLabelLineDefault = {
   show: Nothing,

--- a/src/ECharts/Style/Line.purs
+++ b/src/ECharts/Style/Line.purs
@@ -3,9 +3,8 @@ module ECharts.Style.Line where
 import Prelude
 import Data.Maybe
 import Data.Either
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList)
 import Data.List (toList)
-import Data.Tuple
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
@@ -21,7 +20,7 @@ instance linetypeEncodeJson :: EncodeJson LineType where
   encodeJson a = fromString $ case a of
     Solid -> "solid"
     Dotted -> "dotted"
-    Dashed -> "dashed"    
+    Dashed -> "dashed"
 
 instance linetypeDecodeJson :: DecodeJson LineType where
   decodeJson j = do
@@ -34,7 +33,7 @@ instance linetypeDecodeJson :: DecodeJson LineType where
 
 type LineStyleRec = {
     color :: Maybe Color,
-    "type" :: Maybe LineType, 
+    "type" :: Maybe LineType,
     width :: Maybe Number,
     shadowColor :: Maybe Color,
     shadowOffsetX :: Maybe Number,

--- a/src/ECharts/Style/Link.purs
+++ b/src/ECharts/Style/Link.purs
@@ -3,9 +3,8 @@ module ECharts.Style.Link where
 import Prelude
 import Data.Maybe
 import Data.Either
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList)
 import Data.List (toList)
-import Data.Tuple
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
@@ -17,7 +16,7 @@ import ECharts.Color
 data LinkType = LTCurve | LTLine
 
 instance linkTypeEncodeJson :: EncodeJson LinkType where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     LTCurve -> "curve"
     LTLine -> "line"
 
@@ -42,14 +41,14 @@ newtype LinkStyle = LinkStyle LinkStyleRec
 
 instance linkStyleEncodeJson :: EncodeJson LinkStyle where
   encodeJson (LinkStyle ls) =
-    fromObject $ fromList $ toList 
+    fromObject $ fromList $ toList
     [
       "type" := ls.type,
       "color" := ls.color,
       "width" := ls.width
     ]
 
-instance linkStyleDecodeJson :: DecodeJson LinkStyle where 
+instance linkStyleDecodeJson :: DecodeJson LinkStyle where
   decodeJson j = do
     o <- decodeJson j
     r <- { "type": _

--- a/src/ECharts/Style/Node.purs
+++ b/src/ECharts/Style/Node.purs
@@ -2,9 +2,8 @@ module ECharts.Style.Node where
 
 import Prelude
 import Data.Maybe
-import Data.StrMap (fromList, StrMap (..))
+import Data.StrMap (fromList)
 import Data.List (toList)
-import Data.Tuple
 import Data.Argonaut.Core
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode

--- a/src/ECharts/Style/Text.purs
+++ b/src/ECharts/Style/Text.purs
@@ -1,7 +1,6 @@
 module ECharts.Style.Text where
 
 import Prelude
-import Data.Array (concat)
 import Data.Maybe
 import Data.Either
 import Data.Argonaut.Core
@@ -12,7 +11,6 @@ import Data.List (toList)
 import qualified Data.StrMap as M
 
 
-import ECharts.Common
 import ECharts.Color
 import ECharts.Coords
 
@@ -24,7 +22,7 @@ data TextBaseline = TBLTop
                   | TBLMiddle
 
 instance textBaselineEncodeJson :: EncodeJson TextBaseline where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     TBLTop -> "top"
     TBLBottom -> "bottom"
     TBLMiddle -> "middle"
@@ -36,11 +34,11 @@ instance textBaselineDecodeJson :: DecodeJson TextBaseline where
       "top" -> pure TBLTop
       "bottom" -> pure TBLBottom
       "middle" -> pure TBLMiddle
-      _ -> Left "incorrect text base line" 
+      _ -> Left "incorrect text base line"
 
 data FontStyle = FSNormal | FSItalic | FSOblique
 instance fontStyleEncodeJson :: EncodeJson FontStyle where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     FSNormal -> "normal"
     FSItalic -> "italic"
     FSOblique -> "oblique"
@@ -69,7 +67,7 @@ data FontWeight = FWNormal
                 | FW900
 
 instance fontWeightEncodeJson :: EncodeJson FontWeight where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     FWNormal -> "normal"
     FWBold -> "bold"
     FWBolder -> "bolder"

--- a/src/ECharts/Symbol.purs
+++ b/src/ECharts/Symbol.purs
@@ -6,26 +6,23 @@ module ECharts.Symbol (
 
 import Prelude
 import Data.Argonaut.Core
-import Data.Argonaut.Combinators
 import Data.Argonaut.Encode
 import Data.Argonaut.Decode
-import Data.Maybe
 import Data.Either
 
 import Data.Function
 import Data.Tuple
 
-import ECharts.Item.Data
 import ECharts.Item.Value
 
 
 foreign import func2json :: forall a. a -> Json
 
 data Symbol = Circle | Rectangle | Triangle | Diamond | EmptyCircle | EmptyRectangle
-            | EmptyTriangle | EmptyDiamond 
+            | EmptyTriangle | EmptyDiamond
 
 instance encodeJsonSymbol :: EncodeJson Symbol where
-  encodeJson a = fromString $ case a of 
+  encodeJson a = fromString $ case a of
     Circle -> "circle"
     Rectangle -> "rectangle"
     Triangle -> "triangle"
@@ -48,7 +45,7 @@ instance symbolDecodeJson :: DecodeJson Symbol where
       "emptyTriangle" -> pure EmptyTriangle
       "emptyDiamond" -> pure EmptyDiamond
       _ -> Left "incorrect symbol"
-    
+
 
 data SymbolSize = Size Number | Func (ItemValue -> Number)
 

--- a/src/ECharts/Timeline.purs
+++ b/src/ECharts/Timeline.purs
@@ -39,7 +39,7 @@ instance timelineControlPositionEncodeJson :: EncodeJson TimelineControlPosition
     TCPNone -> "none"
     TCPRight -> "right"
     TCPLeft -> "left"
-                                      
+
 instance timelineControlPositionDecodeJson :: DecodeJson TimelineControlPosition where
   decodeJson j = do
     str <- decodeJson j
@@ -47,7 +47,7 @@ instance timelineControlPositionDecodeJson :: DecodeJson TimelineControlPosition
       "none" -> pure TCPNone
       "right" -> pure TCPRight
       "left" -> pure TCPLeft
-      _ -> Left "incorrect timeline control position" 
+      _ -> Left "incorrect timeline control position"
 
 
 type TimelineRec = {
@@ -122,7 +122,7 @@ instance timelineDecodeJson :: DecodeJson Timeline where
          , notMerge: _
          , realtime: _
          , x: _
-         , x2: _ 
+         , x2: _
          , y: _
          , y2: _
          , width: _
@@ -171,7 +171,7 @@ instance timelineDecodeJson :: DecodeJson Timeline where
          (o .? "data")
     pure $ Timeline r
 
-    
+
 timelineDefault :: TimelineRec
 timelineDefault = {
   show: Nothing,

--- a/src/ECharts/Title.purs
+++ b/src/ECharts/Title.purs
@@ -6,7 +6,7 @@ import Data.Argonaut.Encode
 import Data.Argonaut.Decode
 import Data.Argonaut.Combinators
 import Data.Maybe
-import Data.Either 
+import Data.Either
 import Data.StrMap hiding (toList)
 import Data.List (toList)
 
@@ -54,7 +54,7 @@ newtype Title = Title TitleRec
 
 instance titleEncodeJson :: EncodeJson Title where
   encodeJson (Title obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "text" := obj.text,
       "link" := obj.link,
@@ -110,7 +110,7 @@ instance titleDecodeJson :: DecodeJson Title where
          (o .? "textStyle") <*>
          (o .? "subtextStyle")
     pure $ Title r
-             
+
 
 
 titleDefault :: TitleRec

--- a/src/ECharts/Toolbox.purs
+++ b/src/ECharts/Toolbox.purs
@@ -57,7 +57,7 @@ toolboxDefault =
     textStyle: Nothing,
     feature: Nothing
   }
-  
+
 
 instance toolboxEncodeJson :: EncodeJson Toolbox where
   encodeJson (Toolbox obj) =
@@ -131,7 +131,7 @@ newtype Feature = Feature FeatureRec
 
 instance featureEncodeJson :: EncodeJson Feature where
   encodeJson (Feature obj) =
-    fromObject $ fromList $ toList 
+    fromObject $ fromList $ toList
     [
       "mark" := obj.mark,
       "dataZoom" := obj.dataZoom,
@@ -158,7 +158,7 @@ instance featureDecodeJson :: DecodeJson Feature where
          (o .? "saveAsImage")
     pure $ Feature r
 
-    
+
 featureDefault :: FeatureRec
 featureDefault = {
   mark: Nothing,
@@ -220,7 +220,7 @@ newtype RestoreFeature = RestoreFeature RestoreFeatureRec
 
 instance restoreFeatureEncodeJson :: EncodeJson RestoreFeature where
   encodeJson (RestoreFeature obj) =
-    fromObject $ fromList $ toList 
+    fromObject $ fromList $ toList
     [
       "show" := obj.show,
       "title" := obj.title
@@ -247,7 +247,7 @@ newtype DataZoomFeatureTitle = DataZoomFeatureTitle DataZoomFeatureTitleRec
 
 instance datazoomTitleEncodeJson :: EncodeJson DataZoomFeatureTitle where
   encodeJson (DataZoomFeatureTitle obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "dataZoom" := obj.dataZoom,
       "dataZoomReset" := obj.dataZoomReset
@@ -257,7 +257,7 @@ instance datazoomTitleDecodeJson :: DecodeJson DataZoomFeatureTitle where
   decodeJson j = do
     o <- decodeJson j
     r <- {dataZoom: _ , dataZoomReset: _ } <$> (o .? "dataZoom") <*> (o .? "dataZoomReset")
-    pure $ DataZoomFeatureTitle r 
+    pure $ DataZoomFeatureTitle r
 
 type DataZoomFeatureRec = {
     show :: Maybe Boolean,
@@ -271,10 +271,10 @@ dataZoomFeatureDefault = {
   show: Nothing,
   title: Nothing
   }
-  
+
 instance dataZoomFeatureEncodeJson :: EncodeJson DataZoomFeature where
   encodeJson (DataZoomFeature obj) =
-    fromObject $ fromList $ toList $ 
+    fromObject $ fromList $ toList $
     [
       "show" := obj.show,
       "title" := obj.title
@@ -284,7 +284,7 @@ instance dataZoomFeatureDecodeJson :: DecodeJson DataZoomFeature where
   decodeJson j = do
     o <- decodeJson j
     r <- {show: _ , title: _} <$> (o .? "show") <*> (o .? "title")
-    pure $ DataZoomFeature r 
+    pure $ DataZoomFeature r
 
 type DataViewFeatureRec = {
     show :: Maybe Boolean,
@@ -352,7 +352,7 @@ instance mftitleDecodeJson :: DecodeJson MarkFeatureTitle where
          (o .? "mark") <*>
          (o .? "markUndo") <*>
          (o .? "markClear")
-    pure $ MarkFeatureTitle r 
+    pure $ MarkFeatureTitle r
 
 type MarkFeatureRec = {
     show :: Maybe Boolean,
@@ -365,7 +365,7 @@ newtype MarkFeature = MarkFeature MarkFeatureRec
 
 instance markFeatureEncodeJson :: EncodeJson MarkFeature where
   encodeJson (MarkFeature obj) =
-    fromObject $ fromList $ toList 
+    fromObject $ fromList $ toList
     [
       "show" := obj.show,
       "title" := obj.title,
@@ -381,8 +381,8 @@ instance markFeatureDecodeJson :: DecodeJson MarkFeature where
          (o .? "show") <*>
          (o .? "title") <*>
          (o .? "lineStyle")
-    pure $ MarkFeature r 
-    
+    pure $ MarkFeature r
+
 markFeatureDefault :: MarkFeatureRec
 markFeatureDefault = {
   show: Nothing,
@@ -416,7 +416,7 @@ instance magicTypeDecodeJson :: DecodeJson MagicType where
       "chord" -> pure MagicChord
       "pie" -> pure MagicPie
       "funnel" -> pure MagicFunnel
-      _ -> Left "incorrect magic type" 
+      _ -> Left "incorrect magic type"
 
 
 type MagicTypeFeatureRec = {

--- a/src/ECharts/Tooltip.purs
+++ b/src/ECharts/Tooltip.purs
@@ -6,7 +6,7 @@ module ECharts.Tooltip (
   TooltipAxisPointerRec(),
   Tooltip(..),
   TooltipRec(),
-  
+
   tooltipAxisPointerDefault,
   tooltipDefault
   ) where
@@ -23,13 +23,11 @@ import Data.Function
 import Data.List (toList)
 
 import ECharts.Common
-import ECharts.Coords
 import ECharts.Color
 import ECharts.Style.Text
 import ECharts.Style.Line
 import ECharts.Style.Area
 import ECharts.Formatter
-import ECharts.Utils
 
 data TooltipTrigger = TriggerItem | TriggerAxis
 instance tooltipTriggerEncodeJson :: EncodeJson TooltipTrigger where
@@ -45,7 +43,7 @@ instance tooltipTriggerDecodeJson :: DecodeJson TooltipTrigger where
       _ -> Left $ "incorrect tooltip trigger"
 
 
-foreign import func2json :: forall a. a -> Json 
+foreign import func2json :: forall a. a -> Json
 
 
 data TooltipPosition = Fixed (Array Number) | FuncPos (Array Number -> Array Number)
@@ -201,7 +199,7 @@ instance tooltipDecodeJson :: DecodeJson Tooltip where
          (o .? "textStyle") <*>
          (o .? "enterable")
     pure $ Tooltip r
-         
+
 
 tooltipDefault :: TooltipRec
 tooltipDefault = {

--- a/src/ECharts/Utils.purs
+++ b/src/ECharts/Utils.purs
@@ -6,9 +6,9 @@ import Data.Argonaut.Core
 This func is used to construct copy of object, without null and undefined fields.
 i.e
 {foo: 1, bar: 12, baz: null, quux: undefined} ->
-{foo: 1, bar: 12} 
+{foo: 1, bar: 12}
 -}
-foreign import unnull :: Json -> Json 
+foreign import unnull :: Json -> Json
 
 
 


### PR DESCRIPTION
- Fixed a few inexhaustive pattern matches in JSON decoders—we should throw return `Left` rather than crash
- Fixed a bunch of redundant import warnings
- Removed a few unused type variable quantifications
- Upgraded the build dependencies (new version of `gulp-purescript`)
- Added an optional `gulp trim-whitespace` task to remove trailing whitespace, and ran it (if this causes any merge conflicts, let me know, and I'll remove the commit)
- Regenerated the documentation (slightly different with latest version of PureScript)

(The compiler warnings were obscuring the output from the SlamData build, so I thought I'd fix it at the source.)

https://slamdata.atlassian.net/browse/SD-941
