### PR TITLE
[BREAKING] Make built-in themes FFI-safe

### DIFF
--- a/src/ECharts/Chart.purs
+++ b/src/ECharts/Chart.purs
@@ -15,17 +15,15 @@ import Prelude
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (class MonadEff, liftEff)
 import Control.Monad.Eff.Exception (EXCEPTION)
-
+import Data.Either (either)
 import Data.Foreign (Foreign, toForeign)
-
 import DOM (DOM)
 import DOM.HTML.Types (HTMLElement)
-
 import ECharts.Internal (undefinedValue)
 import ECharts.Monad (DSL, buildObj)
-import ECharts.Theme (Theme(..))
-import ECharts.Types.Phantom (OptionI)
+import ECharts.Theme (Theme, builtInThemeName)
 import ECharts.Types (Chart, ECHARTS)
+import ECharts.Types.Phantom (OptionI)
 
 foreign import initImpl
   ∷ ∀ e. Foreign
@@ -45,8 +43,7 @@ initWithTheme
   ⇒ Theme
   → HTMLElement
   → m Chart
-initWithTheme (ByName name) el = liftEff $ initImpl (toForeign name) el
-initWithTheme (FromObject theme) el = liftEff $ initImpl (toForeign theme) el
+initWithTheme theme el = liftEff $ initImpl (either (toForeign <<< builtInThemeName) toForeign theme) el
 
 foreign import registerTheme
   ∷ ∀ e. String

--- a/src/ECharts/Theme.js
+++ b/src/ECharts/Theme.js
@@ -1,8 +1,12 @@
-require("echarts/theme/dark")
-require("echarts/theme/infographic")
-require("echarts/theme/macarons")
-require("echarts/theme/roma")
-require("echarts/theme/shine")
-require("echarts/theme/vintage")
+"use strict";
 
-exports.forceExport = null
+exports._dark = { name: "dark", value: require("echarts/theme/dark") };
+exports._infographic = { name: "infographic", value: require("echarts/theme/infographic") };
+exports._macarons = { name: "macarons", value: require("echarts/theme/macarons") };
+exports._roma = { name: "roma", value: require("echarts/theme/roma") };
+exports._shine = { name: "shine", value: require("echarts/theme/shine") };
+exports._vintage = { name: "vintage", value: require("echarts/theme/vintage") };
+
+exports.builtInThemeName = function (theme) {
+  return theme.name;
+};

--- a/src/ECharts/Theme.purs
+++ b/src/ECharts/Theme.purs
@@ -1,58 +1,45 @@
 module ECharts.Theme
   ( Theme(..)
+  , BuiltInTheme
+  , builtInThemeName
   , dark
   , infographic
   , macarons
   , roma
   , shine
   , vintage
-  , BuiltInTheme(..)
-  , parseBuiltInTheme
-  , builtInToTheme
   ) where
 
-import Prelude (($), (<>))
 import Data.Either (Either(..))
 import Data.Foreign (Foreign)
 
-foreign import forceExport ∷ Foreign
+type Theme = Either BuiltInTheme Foreign
 
-data Theme = ByName String | FromObject Foreign
-data BuiltInTheme = Infographic | Macarons | Roma | Shine | Vintage | Dark
+foreign import data BuiltInTheme :: Type
 
-parseBuiltInTheme ∷ String → Either String BuiltInTheme
-parseBuiltInTheme str = case str of
-  "infographic" → Right Infographic
-  "macarons" → Right Macarons
-  "roma" → Right Roma
-  "shine" → Right Shine
-  "vintage" → Right Vintage
-  "dark" → Right Dark
-  _ → Left $ "`" <> str <> "` is not builtin theme"
+foreign import builtInThemeName :: BuiltInTheme -> String
 
-builtInToTheme ∷ BuiltInTheme → Theme
-builtInToTheme = case _ of
-  Infographic → ByName "infographic"
-  Macarons → ByName "macarons"
-  Roma → ByName "roma"
-  Shine → ByName "shine"
-  Vintage → ByName "vintage"
-  Dark → ByName "dark"
+dark :: Theme
+dark = Left _dark
 
-dark ∷ Theme
-dark = builtInToTheme Dark
+infographic :: Theme
+infographic = Left _infographic
 
-infographic ∷ Theme
-infographic = builtInToTheme Infographic
+macarons :: Theme
+macarons = Left _macarons
 
-macarons ∷ Theme
-macarons = builtInToTheme Macarons
+roma :: Theme
+roma = Left _roma
 
-roma ∷ Theme
-roma = builtInToTheme Roma
+shine :: Theme
+shine = Left _shine
 
-shine ∷ Theme
-shine = builtInToTheme Shine
+vintage :: Theme
+vintage = Left _vintage
 
-vintage ∷ Theme
-vintage = builtInToTheme Vintage
+foreign import _dark :: BuiltInTheme
+foreign import _infographic :: BuiltInTheme
+foreign import _macarons :: BuiltInTheme
+foreign import _roma :: BuiltInTheme
+foreign import _shine :: BuiltInTheme
+foreign import _vintage :: BuiltInTheme


### PR DESCRIPTION
By making this change we get the best of both worlds in terms of the FFI behaviour:

1. If a theme is unused it will be erased during DCE
2. There should be no chance of DCE or webpack or whatever erasing the used themes, since they're part of a value that is now used.

Having the closed sum type of built in themes didn't really seem to have much advantage, as in theory that sum should be open as people could register their own themes for echarts via the FFI, so now all they have to do is construct one of these `BuiltInTheme` records.